### PR TITLE
fix: models dependency for energy extraction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,16 +12,45 @@ dependencies = [
     "datasets>=3.5.0",
     "fsspec>=2024.12.0",
     "func-timeout>=4.3.5",
-    "mace-torch>=0.3.13",
     "material-hasher",
-    "numpy>=2.2.5",
-    "orb-models==0.5.4",
+    "numpy>=1.26.4",
     "pandas>=2.2.3",
     "pyarrow>=19.0.1",
     "pymatgen>=2025.4.20",
     "pytest>=8.3.5",
     "rich==13.9.4",
-    "torch>=2.7.1",
+    "torch>=2.4.0",
+]
+
+[project.optional-dependencies]
+fairchem = [
+    "fairchem-core>=1.4.0",
+    "e3nn>=0.5.0",
+    "numpy==1.26.4",
+    "torch==2.4.0",
+    "torch_geometric==2.4.0",
+    "pyg-lib==0.4.0+pt24cu124; sys_platform != 'darwin'",
+    "torch_scatter==2.1.2+pt24cu124; sys_platform != 'darwin'",
+    "torch-sparse==0.6.18+pt24cu124; sys_platform != 'darwin'",
+    "torch-cluster==1.6.3+pt24cu124; sys_platform != 'darwin'",
+    "torch-spline-conv==1.2.2+pt24cu124; sys_platform != 'darwin'",
+]
+mace = [
+    "mace-torch>=0.3.13",
+    "e3nn==0.4.4",
+    "numpy==2.2.3",
+    "torch==2.6.0",
+    "torch_scatter==2.1.2+pt26cu124; sys_platform != 'darwin'",
+    "torch-sparse==0.6.18+pt26cu124; sys_platform != 'darwin'",
+    "torch-cluster==1.6.3+pt26cu124; sys_platform != 'darwin'",
+    "torch-spline-conv==1.2.2+pt26cu124; sys_platform != 'darwin'",
+]
+orb = [
+    "orb-models>=0.5.1",
+    "torch_scatter==2.1.2+pt26cu124; sys_platform != 'darwin'",
+    "torch-sparse==0.6.18+pt26cu124; sys_platform != 'darwin'",
+    "torch-cluster==1.6.3+pt26cu124; sys_platform != 'darwin'",
+    "torch-spline-conv==1.2.2+pt26cu124; sys_platform != 'darwin'",
 ]
 
 [project.scripts]
@@ -50,6 +79,19 @@ dev-dependencies = [
     "lxml>=5.3.0",
     "requests>=2.32.3",
     "botocore>=1.36.20",
+]
+find-links = [
+  "https://data.pyg.org/whl/torch-2.6.0+cu124.html",
+  "https://data.pyg.org/whl/torch-2.6.0+cpu.html",
+  "https://data.pyg.org/whl/torch-2.4.0+cu124.html",
+  "https://data.pyg.org/whl/torch-2.4.0+cpu.html",
+]
+conflicts = [
+    [
+        { extra = "fairchem" },
+        { extra = "mace" },
+        { extra = "orb" }
+    ]
 ]
 
 [tool.uv.sources]

--- a/uv.lock
+++ b/uv.lock
@@ -1,12 +1,41 @@
 version = 1
+revision = 1
 requires-python = ">=3.11"
 resolution-markers = [
-    "python_full_version >= '3.13' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version >= '3.13' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform != 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'win32'",
-    "python_full_version < '3.12' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.13' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform == 'win32' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform == 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform == 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+]
+conflicts = [[
+    { package = "lematerial-forgebench", extra = "fairchem" },
+    { package = "lematerial-forgebench", extra = "mace" },
+    { package = "lematerial-forgebench", extra = "orb" },
+]]
+
+[[package]]
+name = "absl-py"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/15/18693af986560a5c3cc0b84a8046b536ffb2cdb536e03cce897f2759e284/absl_py-2.3.0.tar.gz", hash = "sha256:d96fda5c884f1b22178852f30ffa85766d50b99e00775ea626c23304f582fc4f", size = 116400 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/04/9d75e1d3bb4ab8ec67ff10919476ccdee06c098bcfcf3a352da5f985171d/absl_py-2.3.0-py3-none-any.whl", hash = "sha256:9824a48b654a306168f63e0d97714665f8490b8d89ec7bf2efc24bf67cf579b3", size = 135657 },
 ]
 
 [[package]]
@@ -108,12 +137,29 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643 },
+]
+
+[[package]]
+name = "antlr4-python3-runtime"
+version = "4.9.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/38/7859ff46355f76f8d19459005ca000b6e7012f2f1ca597746cbcd1fbfe5e/antlr4-python3-runtime-4.9.3.tar.gz", hash = "sha256:f224469b4168294902bb1efa80a8bf7855f24c99aef99cbefc1bcd3cce77881b", size = 117034 }
+
+[[package]]
 name = "ase"
 version = "3.25.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "matplotlib" },
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-fairchem' or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "numpy", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-mace' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-orb' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace')" },
     { name = "scipy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e8/a1/5735ced2f159979f5b27c4083126b7796a5750cee6f027864e59818a5b76/ase-3.25.0.tar.gz", hash = "sha256:374cf8ca9fe588f05d6e856da3c9c17ef262dc968027b231d449334140c962c2", size = 2400055 }
@@ -156,7 +202,9 @@ dependencies = [
     { name = "gemmi" },
     { name = "joblib" },
     { name = "numba" },
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-fairchem' or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "numpy", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-mace' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-orb' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace')" },
     { name = "pandas" },
     { name = "scikit-learn" },
     { name = "scipy" },
@@ -331,6 +379,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cloudpickle"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/39/069100b84d7418bc358d81669d5748efb14b9cceacd2f9c75f550424132f/cloudpickle-3.1.1.tar.gz", hash = "sha256:b216fa8ae4019d5482a8ac3c95d8f6346115d8835911fd4aefd1a445e4242c64", size = 22113 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/e8/64c37fadfc2816a7701fa8a6ed8d87327c7d54eacfbfb6edab14a2f2be75/cloudpickle-3.1.1-py3-none-any.whl", hash = "sha256:c8c5a44295039331ee9dad40ba100a9c7297b6f988e50e87ccdf3765a668350e", size = 20992 },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -353,7 +410,9 @@ name = "contourpy"
 version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-fairchem' or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "numpy", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-mace' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-orb' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130 }
 wheels = [
@@ -421,7 +480,9 @@ dependencies = [
     { name = "fsspec", extra = ["http"] },
     { name = "huggingface-hub" },
     { name = "multiprocess" },
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-fairchem' or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "numpy", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-mace' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-orb' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace')" },
     { name = "packaging" },
     { name = "pandas" },
     { name = "pyarrow" },
@@ -498,15 +559,44 @@ wheels = [
 name = "e3nn"
 version = "0.4.4"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform != 'win32'",
+]
 dependencies = [
     { name = "opt-einsum-fx" },
     { name = "scipy" },
-    { name = "sympy" },
-    { name = "torch" },
+    { name = "sympy", version = "1.13.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "torch", version = "2.6.0", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/aa/98/8e7102dea93106603383fda23bf96649c397a37b910e7c76086e584cd92d/e3nn-0.4.4.tar.gz", hash = "sha256:51c91a84c1fb72e7e3600000958fa8caad48f8270937090fb8d0f8bfffbb3525", size = 361661 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/b6/c8327065d1dd8bca28521fe65ff72b649ed17ca8a1f0c1f498006d7567b7/e3nn-0.4.4-py3-none-any.whl", hash = "sha256:87d99876abb362a6e07d555d10752ff2e20c2b7731d8928ebe5d9121fb019f84", size = 387707 },
+]
+
+[[package]]
+name = "e3nn"
+version = "0.5.6"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and sys_platform == 'linux'",
+    "python_full_version >= '3.12' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'linux'",
+    "python_full_version < '3.12' and sys_platform != 'linux' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "opt-einsum-fx" },
+    { name = "scipy" },
+    { name = "sympy", version = "1.14.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "torch", version = "2.4.0", source = { registry = "https://pypi.org/simple" } },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/97/ac/ac6120e6e001677b6bbaeee3f7c40af784a1758568ae3246df7b5c3b9552/e3nn-0.5.6.tar.gz", hash = "sha256:e28aa6f67d9c090300d390f9e08fb57211d60562971ae3237e30023ff17093b1", size = 435651 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/b4/c5101bb2a6417506241a9b1beb39ce7bce18c652bcf3ecd84d9158a4d53c/e3nn-0.5.6-py3-none-any.whl", hash = "sha256:172b450cf9c9cab0f341826e963a331675c085c502412ac9ab9d804107913c4c", size = 448027 },
 ]
 
 [[package]]
@@ -516,6 +606,36 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/91/50/a9d80c47ff289c611ff12e63f7c5d13942c65d68125160cefd768c73e6e4/executing-2.2.0.tar.gz", hash = "sha256:5d108c028108fe2551d1a7b2e8b713341e2cb4fc0aa7dcf966fa4327a5226755", size = 978693 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/8f/c4d9bafc34ad7ad5d8dc16dd1347ee0e507a52c3adb6bfa8887e1c6a26ba/executing-2.2.0-py2.py3-none-any.whl", hash = "sha256:11387150cad388d62750327a53d3339fad4888b39a6fe233c3afbb54ecffd3aa", size = 26702 },
+]
+
+[[package]]
+name = "fairchem-core"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ase" },
+    { name = "e3nn", version = "0.5.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "huggingface-hub" },
+    { name = "hydra-core" },
+    { name = "lmdb" },
+    { name = "numba" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "orjson" },
+    { name = "pydantic" },
+    { name = "pymatgen" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "submitit" },
+    { name = "tensorboard" },
+    { name = "torch", version = "2.4.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "torch-geometric" },
+    { name = "torchtnt" },
+    { name = "tqdm" },
+    { name = "wandb" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/c4/73c1f2eccd7513b1a95cb0cec43a2809cd48587becd167ea2a61eaa64a56/fairchem_core-1.10.0.tar.gz", hash = "sha256:ec088258065aa6c6cb6a00c3b6edcf95ce023e7d12d0bd09a280329b8cf4fa7a", size = 347037 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/98/6bda48097679cb44b86d7b91fa41bdfb8b121c95309ca12195ee1e57d5a1/fairchem_core-1.10.0-py3-none-any.whl", hash = "sha256:cad591d8423a5f8ccb1d164bb32686586668a32aa9399baac0f82448ad92e136", size = 456286 },
 ]
 
 [[package]]
@@ -816,11 +936,49 @@ wheels = [
 ]
 
 [[package]]
+name = "grpcio"
+version = "1.73.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/7b/ca3f561aeecf0c846d15e1b38921a60dffffd5d4113931198fbf455334ee/grpcio-1.73.0.tar.gz", hash = "sha256:3af4c30918a7f0d39de500d11255f8d9da4f30e94a2033e70fe2a720e184bd8e", size = 12786424 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/31/9de81fd12f7b27e6af403531b7249d76f743d58e0654e624b3df26a43ce2/grpcio-1.73.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:51036f641f171eebe5fa7aaca5abbd6150f0c338dab3a58f9111354240fe36ec", size = 5363773 },
+    { url = "https://files.pythonhosted.org/packages/32/9e/2cb78be357a7f1fc4942b81468ef3c7e5fd3df3ac010540459c10895a57b/grpcio-1.73.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:d12bbb88381ea00bdd92c55aff3da3391fd85bc902c41275c8447b86f036ce0f", size = 10621912 },
+    { url = "https://files.pythonhosted.org/packages/59/2f/b43954811a2e218a2761c0813800773ac0ca187b94fd2b8494e8ef232dc8/grpcio-1.73.0-cp311-cp311-manylinux_2_17_aarch64.whl", hash = "sha256:483c507c2328ed0e01bc1adb13d1eada05cc737ec301d8e5a8f4a90f387f1790", size = 5807985 },
+    { url = "https://files.pythonhosted.org/packages/1b/bf/68e9f47e7ee349ffee712dcd907ee66826cf044f0dec7ab517421e56e857/grpcio-1.73.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c201a34aa960c962d0ce23fe5f423f97e9d4b518ad605eae6d0a82171809caaa", size = 6448218 },
+    { url = "https://files.pythonhosted.org/packages/af/dd/38ae43dd58480d609350cf1411fdac5c2ebb243e2c770f6f7aa3773d5e29/grpcio-1.73.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:859f70c8e435e8e1fa060e04297c6818ffc81ca9ebd4940e180490958229a45a", size = 6044343 },
+    { url = "https://files.pythonhosted.org/packages/93/44/b6770b55071adb86481f36dae87d332fcad883b7f560bba9a940394ba018/grpcio-1.73.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:e2459a27c6886e7e687e4e407778425f3c6a971fa17a16420227bda39574d64b", size = 6135858 },
+    { url = "https://files.pythonhosted.org/packages/d3/9f/63de49fcef436932fcf0ffb978101a95c83c177058dbfb56dbf30ab81659/grpcio-1.73.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:e0084d4559ee3dbdcce9395e1bc90fdd0262529b32c417a39ecbc18da8074ac7", size = 6775806 },
+    { url = "https://files.pythonhosted.org/packages/4d/67/c11f1953469162e958f09690ec3a9be3fdb29dea7f5661362a664f9d609a/grpcio-1.73.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:ef5fff73d5f724755693a464d444ee0a448c6cdfd3c1616a9223f736c622617d", size = 6308413 },
+    { url = "https://files.pythonhosted.org/packages/ba/6a/9dd04426337db07f28bd51a986b7a038ba56912c81b5bb1083c17dd63404/grpcio-1.73.0-cp311-cp311-win32.whl", hash = "sha256:965a16b71a8eeef91fc4df1dc40dc39c344887249174053814f8a8e18449c4c3", size = 3678972 },
+    { url = "https://files.pythonhosted.org/packages/04/8b/8c0a8a4fdc2e7977d325eafc587c9cf468039693ac23ad707153231d3cb2/grpcio-1.73.0-cp311-cp311-win_amd64.whl", hash = "sha256:b71a7b4483d1f753bbc11089ff0f6fa63b49c97a9cc20552cded3fcad466d23b", size = 4342967 },
+    { url = "https://files.pythonhosted.org/packages/9d/4d/e938f3a0e51a47f2ce7e55f12f19f316e7074770d56a7c2765e782ec76bc/grpcio-1.73.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:fb9d7c27089d9ba3746f18d2109eb530ef2a37452d2ff50f5a6696cd39167d3b", size = 5334911 },
+    { url = "https://files.pythonhosted.org/packages/13/56/f09c72c43aa8d6f15a71f2c63ebdfac9cf9314363dea2598dc501d8370db/grpcio-1.73.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:128ba2ebdac41e41554d492b82c34586a90ebd0766f8ebd72160c0e3a57b9155", size = 10601460 },
+    { url = "https://files.pythonhosted.org/packages/20/e3/85496edc81e41b3c44ebefffc7bce133bb531120066877df0f910eabfa19/grpcio-1.73.0-cp312-cp312-manylinux_2_17_aarch64.whl", hash = "sha256:068ecc415f79408d57a7f146f54cdf9f0acb4b301a52a9e563973dc981e82f3d", size = 5759191 },
+    { url = "https://files.pythonhosted.org/packages/88/cc/fef74270a6d29f35ad744bfd8e6c05183f35074ff34c655a2c80f3b422b2/grpcio-1.73.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6ddc1cfb2240f84d35d559ade18f69dcd4257dbaa5ba0de1a565d903aaab2968", size = 6409961 },
+    { url = "https://files.pythonhosted.org/packages/b0/e6/13cfea15e3b8f79c4ae7b676cb21fab70978b0fde1e1d28bb0e073291290/grpcio-1.73.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e53007f70d9783f53b41b4cf38ed39a8e348011437e4c287eee7dd1d39d54b2f", size = 6003948 },
+    { url = "https://files.pythonhosted.org/packages/c2/ed/b1a36dad4cc0dbf1f83f6d7b58825fefd5cc9ff3a5036e46091335649473/grpcio-1.73.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:4dd8d8d092efede7d6f48d695ba2592046acd04ccf421436dd7ed52677a9ad29", size = 6103788 },
+    { url = "https://files.pythonhosted.org/packages/e7/c8/d381433d3d46d10f6858126d2d2245ef329e30f3752ce4514c93b95ca6fc/grpcio-1.73.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:70176093d0a95b44d24baa9c034bb67bfe2b6b5f7ebc2836f4093c97010e17fd", size = 6749508 },
+    { url = "https://files.pythonhosted.org/packages/87/0a/ff0c31dbd15e63b34320efafac647270aa88c31aa19ff01154a73dc7ce86/grpcio-1.73.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:085ebe876373ca095e24ced95c8f440495ed0b574c491f7f4f714ff794bbcd10", size = 6284342 },
+    { url = "https://files.pythonhosted.org/packages/fd/73/f762430c0ba867403b9d6e463afe026bf019bd9206eee753785239719273/grpcio-1.73.0-cp312-cp312-win32.whl", hash = "sha256:cfc556c1d6aef02c727ec7d0016827a73bfe67193e47c546f7cadd3ee6bf1a60", size = 3669319 },
+    { url = "https://files.pythonhosted.org/packages/10/8b/3411609376b2830449cf416f457ad9d2aacb7f562e1b90fdd8bdedf26d63/grpcio-1.73.0-cp312-cp312-win_amd64.whl", hash = "sha256:bbf45d59d090bf69f1e4e1594832aaf40aa84b31659af3c5e2c3f6a35202791a", size = 4335596 },
+    { url = "https://files.pythonhosted.org/packages/60/da/6f3f7a78e5455c4cbe87c85063cc6da05d65d25264f9d4aed800ece46294/grpcio-1.73.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:da1d677018ef423202aca6d73a8d3b2cb245699eb7f50eb5f74cae15a8e1f724", size = 5335867 },
+    { url = "https://files.pythonhosted.org/packages/53/14/7d1f2526b98b9658d7be0bb163fd78d681587de6709d8b0c74b4b481b013/grpcio-1.73.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:36bf93f6a657f37c131d9dd2c391b867abf1426a86727c3575393e9e11dadb0d", size = 10595587 },
+    { url = "https://files.pythonhosted.org/packages/02/24/a293c398ae44e741da1ed4b29638edbb002258797b07a783f65506165b4c/grpcio-1.73.0-cp313-cp313-manylinux_2_17_aarch64.whl", hash = "sha256:d84000367508ade791d90c2bafbd905574b5ced8056397027a77a215d601ba15", size = 5765793 },
+    { url = "https://files.pythonhosted.org/packages/e1/24/d84dbd0b5bf36fb44922798d525a85cefa2ffee7b7110e61406e9750ed15/grpcio-1.73.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c98ba1d928a178ce33f3425ff823318040a2b7ef875d30a0073565e5ceb058d9", size = 6415494 },
+    { url = "https://files.pythonhosted.org/packages/5e/85/c80dc65aed8e9dce3d54688864bac45331d9c7600985541f18bd5cb301d4/grpcio-1.73.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a73c72922dfd30b396a5f25bb3a4590195ee45ecde7ee068acb0892d2900cf07", size = 6007279 },
+    { url = "https://files.pythonhosted.org/packages/37/fc/207c00a4c6fa303d26e2cbd62fbdb0582facdfd08f55500fd83bf6b0f8db/grpcio-1.73.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:10e8edc035724aba0346a432060fd192b42bd03675d083c01553cab071a28da5", size = 6105505 },
+    { url = "https://files.pythonhosted.org/packages/72/35/8fe69af820667b87ebfcb24214e42a1d53da53cb39edd6b4f84f6b36da86/grpcio-1.73.0-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:f5cdc332b503c33b1643b12ea933582c7b081957c8bc2ea4cc4bc58054a09288", size = 6753792 },
+    { url = "https://files.pythonhosted.org/packages/e2/d8/738c77c1e821e350da4a048849f695ff88a02b291f8c69db23908867aea6/grpcio-1.73.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:07ad7c57233c2109e4ac999cb9c2710c3b8e3f491a73b058b0ce431f31ed8145", size = 6287593 },
+    { url = "https://files.pythonhosted.org/packages/09/ec/8498eabc018fa39ae8efe5e47e3f4c1bc9ed6281056713871895dc998807/grpcio-1.73.0-cp313-cp313-win32.whl", hash = "sha256:0eb5df4f41ea10bda99a802b2a292d85be28958ede2a50f2beb8c7fc9a738419", size = 3668637 },
+    { url = "https://files.pythonhosted.org/packages/d7/35/347db7d2e7674b621afd21b12022e7f48c7b0861b5577134b4e939536141/grpcio-1.73.0-cp313-cp313-win_amd64.whl", hash = "sha256:38cf518cc54cd0c47c9539cefa8888549fcc067db0b0c66a46535ca8032020c4", size = 4335872 },
+]
+
+[[package]]
 name = "h5py"
 version = "3.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "2.2.3", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5d/57/dfb3c5c3f1bf5f5ef2e59a22dec4ff1f3d7408b55bfcefcfb0ea69ef21c6/h5py-3.14.0.tar.gz", hash = "sha256:2372116b2e0d5d3e5e705b7f663f7c8d96fa79a4052d250484ef91d24d6a08f4", size = 424323 }
 wheels = [
@@ -873,6 +1031,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8f/fb/7fcbafabdf470ffb5457b756cc1f659b4e88a9ff37c108e6c7a5ab5e781e/huggingface_hub-0.32.6.tar.gz", hash = "sha256:8e960f23dc57519c6c2a0bbc7e9bc030eaa14e7f2d61f8e68fd3d025dabed2fa", size = 424961 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/42/dd58e603c5b069c4e4759c7c44e4f5ccdc2ce02185848232775f5d6d5d50/huggingface_hub-0.32.6-py3-none-any.whl", hash = "sha256:32cde9558c965477556edca72352621def7fbc42e167aaf33f4cdb9af65bb28b", size = 512800 },
+]
+
+[[package]]
+name = "hydra-core"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "antlr4-python3-runtime" },
+    { name = "omegaconf" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/8e/07e42bc434a847154083b315779b0a81d567154504624e181caf2c71cd98/hydra-core-1.3.2.tar.gz", hash = "sha256:8a878ed67216997c3e9d88a8e72e7b4767e81af37afb4ea3334b269a4390a824", size = 3263494 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/50/e0edd38dcd63fb26a8547f13d28f7a008bc4a3fd4eb4ff030673f22ad41a/hydra_core-1.3.2-py3-none-any.whl", hash = "sha256:fa0238a9e31df3373b35b0bfb672c34cc92718d21f81311d8996a16de1141d8b", size = 154547 },
 ]
 
 [[package]]
@@ -929,17 +1101,17 @@ name = "ipython"
 version = "9.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb') or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
     { name = "decorator" },
     { name = "ipython-pygments-lexers" },
     { name = "jedi" },
     { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "pexpect", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (sys_platform == 'emscripten' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform == 'emscripten' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform == 'win32' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (sys_platform == 'win32' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform == 'win32' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
     { name = "prompt-toolkit" },
     { name = "pygments" },
     { name = "stack-data" },
     { name = "traitlets" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb') or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/dc/09/4c7e06b96fbd203e06567b60fb41b06db606b6a82db6db7b2c85bb72a15c/ipython-9.3.0.tar.gz", hash = "sha256:79eb896f9f23f50ad16c3bc205f686f6e030ad246cc309c6279a242b14afe9d8", size = 4426460 }
 wheels = [
@@ -1076,16 +1248,49 @@ dependencies = [
     { name = "datasets" },
     { name = "fsspec" },
     { name = "func-timeout" },
-    { name = "mace-torch" },
     { name = "material-hasher" },
-    { name = "numpy" },
-    { name = "orb-models" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-fairchem' or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "numpy", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-mace' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-orb' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace')" },
     { name = "pandas" },
     { name = "pyarrow" },
     { name = "pymatgen" },
     { name = "pytest" },
     { name = "rich" },
-    { name = "torch" },
+    { name = "torch", version = "2.4.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-fairchem' or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "torch", version = "2.6.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-mace' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "torch", version = "2.7.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-orb' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace')" },
+]
+
+[package.optional-dependencies]
+fairchem = [
+    { name = "e3nn", version = "0.5.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "fairchem-core" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "pyg-lib", marker = "sys_platform != 'darwin'" },
+    { name = "torch", version = "2.4.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "torch-cluster", version = "1.6.3+pt24cu124", source = { registry = "https://data.pyg.org/whl/torch-2.4.0+cu124.html" }, marker = "sys_platform != 'darwin'" },
+    { name = "torch-geometric" },
+    { name = "torch-scatter", version = "2.1.2+pt24cu124", source = { registry = "https://data.pyg.org/whl/torch-2.4.0+cu124.html" }, marker = "sys_platform != 'darwin'" },
+    { name = "torch-sparse", version = "0.6.18+pt24cu124", source = { registry = "https://data.pyg.org/whl/torch-2.4.0+cu124.html" }, marker = "sys_platform != 'darwin'" },
+    { name = "torch-spline-conv", version = "1.2.2+pt24cu124", source = { registry = "https://data.pyg.org/whl/torch-2.4.0+cu124.html" }, marker = "sys_platform != 'darwin'" },
+]
+mace = [
+    { name = "e3nn", version = "0.4.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "mace-torch" },
+    { name = "numpy", version = "2.2.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "torch", version = "2.6.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "torch-cluster", version = "1.6.3+pt26cu124", source = { registry = "https://data.pyg.org/whl/torch-2.6.0+cu124.html" }, marker = "sys_platform != 'darwin'" },
+    { name = "torch-scatter", version = "2.1.2+pt26cu124", source = { registry = "https://data.pyg.org/whl/torch-2.6.0+cu124.html" }, marker = "sys_platform != 'darwin'" },
+    { name = "torch-sparse", version = "0.6.18+pt26cu124", source = { registry = "https://data.pyg.org/whl/torch-2.6.0+cu124.html" }, marker = "sys_platform != 'darwin'" },
+    { name = "torch-spline-conv", version = "1.2.2+pt26cu124", source = { registry = "https://data.pyg.org/whl/torch-2.6.0+cu124.html" }, marker = "sys_platform != 'darwin'" },
+]
+orb = [
+    { name = "orb-models" },
+    { name = "torch-cluster", version = "1.6.3+pt26cu124", source = { registry = "https://data.pyg.org/whl/torch-2.6.0+cu124.html" }, marker = "sys_platform != 'darwin'" },
+    { name = "torch-scatter", version = "2.1.2+pt26cu124", source = { registry = "https://data.pyg.org/whl/torch-2.6.0+cu124.html" }, marker = "sys_platform != 'darwin'" },
+    { name = "torch-sparse", version = "0.6.18+pt26cu124", source = { registry = "https://data.pyg.org/whl/torch-2.6.0+cu124.html" }, marker = "sys_platform != 'darwin'" },
+    { name = "torch-spline-conv", version = "1.2.2+pt26cu124", source = { registry = "https://data.pyg.org/whl/torch-2.6.0+cu124.html" }, marker = "sys_platform != 'darwin'" },
 ]
 
 [package.dev-dependencies]
@@ -1114,19 +1319,41 @@ requires-dist = [
     { name = "ase", specifier = ">=3.25.0" },
     { name = "click", specifier = ">=8.1.8" },
     { name = "datasets", specifier = ">=3.5.0" },
+    { name = "e3nn", marker = "extra == 'fairchem'", specifier = ">=0.5.0" },
+    { name = "e3nn", marker = "extra == 'mace'", specifier = "==0.4.4" },
+    { name = "fairchem-core", marker = "extra == 'fairchem'", specifier = ">=1.4.0" },
     { name = "fsspec", specifier = ">=2024.12.0" },
     { name = "func-timeout", specifier = ">=4.3.5" },
-    { name = "mace-torch", specifier = ">=0.3.13" },
+    { name = "mace-torch", marker = "extra == 'mace'", specifier = ">=0.3.13" },
     { name = "material-hasher", git = "https://github.com/lematerial/material-hasher.git" },
-    { name = "numpy", specifier = ">=2.2.5" },
-    { name = "orb-models", specifier = "==0.5.4" },
+    { name = "numpy", specifier = ">=1.26.4" },
+    { name = "numpy", marker = "extra == 'fairchem'", specifier = "==1.26.4" },
+    { name = "numpy", marker = "extra == 'mace'", specifier = "==2.2.3" },
+    { name = "orb-models", marker = "extra == 'orb'", specifier = ">=0.5.1" },
     { name = "pandas", specifier = ">=2.2.3" },
     { name = "pyarrow", specifier = ">=19.0.1" },
+    { name = "pyg-lib", marker = "sys_platform != 'darwin' and extra == 'fairchem'", specifier = "==0.4.0+pt24cu124" },
     { name = "pymatgen", specifier = ">=2025.4.20" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "rich", specifier = "==13.9.4" },
-    { name = "torch", specifier = ">=2.7.1" },
+    { name = "torch", specifier = ">=2.4.0" },
+    { name = "torch", marker = "extra == 'fairchem'", specifier = "==2.4.0" },
+    { name = "torch", marker = "extra == 'mace'", specifier = "==2.6.0" },
+    { name = "torch-cluster", marker = "sys_platform != 'darwin' and extra == 'fairchem'", specifier = "==1.6.3+pt24cu124" },
+    { name = "torch-cluster", marker = "sys_platform != 'darwin' and extra == 'mace'", specifier = "==1.6.3+pt26cu124" },
+    { name = "torch-cluster", marker = "sys_platform != 'darwin' and extra == 'orb'", specifier = "==1.6.3+pt26cu124" },
+    { name = "torch-geometric", marker = "extra == 'fairchem'", specifier = "==2.4.0" },
+    { name = "torch-scatter", marker = "sys_platform != 'darwin' and extra == 'fairchem'", specifier = "==2.1.2+pt24cu124" },
+    { name = "torch-scatter", marker = "sys_platform != 'darwin' and extra == 'mace'", specifier = "==2.1.2+pt26cu124" },
+    { name = "torch-scatter", marker = "sys_platform != 'darwin' and extra == 'orb'", specifier = "==2.1.2+pt26cu124" },
+    { name = "torch-sparse", marker = "sys_platform != 'darwin' and extra == 'fairchem'", specifier = "==0.6.18+pt24cu124" },
+    { name = "torch-sparse", marker = "sys_platform != 'darwin' and extra == 'mace'", specifier = "==0.6.18+pt26cu124" },
+    { name = "torch-sparse", marker = "sys_platform != 'darwin' and extra == 'orb'", specifier = "==0.6.18+pt26cu124" },
+    { name = "torch-spline-conv", marker = "sys_platform != 'darwin' and extra == 'fairchem'", specifier = "==1.2.2+pt24cu124" },
+    { name = "torch-spline-conv", marker = "sys_platform != 'darwin' and extra == 'mace'", specifier = "==1.2.2+pt26cu124" },
+    { name = "torch-spline-conv", marker = "sys_platform != 'darwin' and extra == 'orb'", specifier = "==1.2.2+pt26cu124" },
 ]
+provides-extras = ["fairchem", "mace", "orb"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1211,8 +1438,8 @@ name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb') or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "win32-setctime", marker = "sys_platform == 'win32' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb') or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559 }
 wheels = [
@@ -1285,20 +1512,20 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ase" },
     { name = "configargparse" },
-    { name = "e3nn" },
+    { name = "e3nn", version = "0.4.4", source = { registry = "https://pypi.org/simple" } },
     { name = "gitpython" },
     { name = "h5py" },
     { name = "lmdb" },
     { name = "matplotlib" },
     { name = "matscipy" },
-    { name = "numpy" },
+    { name = "numpy", version = "2.2.3", source = { registry = "https://pypi.org/simple" } },
     { name = "opt-einsum" },
     { name = "orjson" },
     { name = "pandas" },
     { name = "prettytable" },
     { name = "python-hostlist" },
     { name = "pyyaml" },
-    { name = "torch" },
+    { name = "torch", version = "2.6.0", source = { registry = "https://pypi.org/simple" } },
     { name = "torch-ema" },
     { name = "torchmetrics" },
     { name = "tqdm" },
@@ -1306,6 +1533,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/5d/a4f6edf70c9383208ed74abe758ee17c9f6d785d8695eb51889cdd62c525/mace_torch-0.3.13.tar.gz", hash = "sha256:32b44478cb40ffe625216a81bcbac001165baff1fa9378a47ad50c4550806da5", size = 175537 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/e2/bbb81a1a03c539a38402c1a21debc8e6f09b4d8bbfd84fa54b3d43838f82/mace_torch-0.3.13-py3-none-any.whl", hash = "sha256:e0aeef5fdb493f94436e4a806f89e051240d79202bccd6bacf5c6007d9adf75a", size = 202043 },
+]
+
+[[package]]
+name = "markdown"
+version = "3.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/15/222b423b0b88689c266d9eac4e61396fe2cc53464459d6a37618ac863b24/markdown-3.8.tar.gz", hash = "sha256:7df81e63f0df5c4b24b7d156eb81e4690595239b7d70937d0409f1b0de319c6f", size = 360906 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/3f/afe76f8e2246ffbc867440cbcf90525264df0e658f8a5ca1f872b3f6192a/markdown-3.8-py3-none-any.whl", hash = "sha256:794a929b79c5af141ef5ab0f2f642d0f7b1872981250230e72682346f7cc90dc", size = 106210 },
 ]
 
 [[package]]
@@ -1380,7 +1616,9 @@ dependencies = [
     { name = "pymatgen" },
     { name = "setuptools" },
     { name = "structuregraph-helpers" },
-    { name = "torch" },
+    { name = "torch", version = "2.4.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-fairchem' or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "torch", version = "2.6.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-mace' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "torch", version = "2.7.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-orb' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace')" },
 ]
 
 [[package]]
@@ -1392,7 +1630,9 @@ dependencies = [
     { name = "cycler" },
     { name = "fonttools" },
     { name = "kiwisolver" },
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-fairchem' or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "numpy", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-mace' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-orb' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace')" },
     { name = "packaging" },
     { name = "pillow" },
     { name = "pyparsing" },
@@ -1444,7 +1684,7 @@ version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ase" },
-    { name = "numpy" },
+    { name = "numpy", version = "2.2.3", source = { registry = "https://pypi.org/simple" } },
     { name = "packaging" },
     { name = "scipy" },
 ]
@@ -1476,7 +1716,9 @@ name = "monty"
 version = "2025.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-fairchem' or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "numpy", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-mace' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-orb' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace')" },
     { name = "ruamel-yaml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/89/54/a1b2b4c9b16ebc5ea72cf22b1a6bb7ceaa79187fbf22a404c9677c8f90dd/monty-2025.3.3.tar.gz", hash = "sha256:16c1eb54b2372e765c2f3f14cff01cc76ab55c3cc12b27d49962fb8072310ae0", size = 85592 }
@@ -1603,6 +1845,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963 },
+]
+
+[[package]]
 name = "narwhals"
 version = "1.42.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1635,7 +1886,9 @@ version = "0.61.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "llvmlite" },
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-fairchem' or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "numpy", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-mace' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-orb' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/a0/e21f57604304aa03ebb8e098429222722ad99176a4f979d34af1d1ee80da/numba-0.61.2.tar.gz", hash = "sha256:8750ee147940a6637b80ecf7f95062185ad8726c8c28a2295b8ec1160a196f7d", size = 2820615 }
 wheels = [
@@ -1658,8 +1911,106 @@ wheels = [
 
 [[package]]
 name = "numpy"
+version = "1.26.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and sys_platform == 'linux'",
+    "python_full_version >= '3.12' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'linux'",
+    "python_full_version < '3.12' and sys_platform != 'linux' and sys_platform != 'win32'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010", size = 15786129 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/57/baae43d14fe163fa0e4c47f307b6b2511ab8d7d30177c491960504252053/numpy-1.26.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4c66707fabe114439db9068ee468c26bbdf909cac0fb58686a42a24de1760c71", size = 20630554 },
+    { url = "https://files.pythonhosted.org/packages/1a/2e/151484f49fd03944c4a3ad9c418ed193cfd02724e138ac8a9505d056c582/numpy-1.26.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:edd8b5fe47dab091176d21bb6de568acdd906d1887a4584a15a9a96a1dca06ef", size = 13997127 },
+    { url = "https://files.pythonhosted.org/packages/79/ae/7e5b85136806f9dadf4878bf73cf223fe5c2636818ba3ab1c585d0403164/numpy-1.26.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ab55401287bfec946ced39700c053796e7cc0e3acbef09993a9ad2adba6ca6e", size = 14222994 },
+    { url = "https://files.pythonhosted.org/packages/3a/d0/edc009c27b406c4f9cbc79274d6e46d634d139075492ad055e3d68445925/numpy-1.26.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:666dbfb6ec68962c033a450943ded891bed2d54e6755e35e5835d63f4f6931d5", size = 18252005 },
+    { url = "https://files.pythonhosted.org/packages/09/bf/2b1aaf8f525f2923ff6cfcf134ae5e750e279ac65ebf386c75a0cf6da06a/numpy-1.26.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:96ff0b2ad353d8f990b63294c8986f1ec3cb19d749234014f4e7eb0112ceba5a", size = 13885297 },
+    { url = "https://files.pythonhosted.org/packages/df/a0/4e0f14d847cfc2a633a1c8621d00724f3206cfeddeb66d35698c4e2cf3d2/numpy-1.26.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:60dedbb91afcbfdc9bc0b1f3f402804070deed7392c23eb7a7f07fa857868e8a", size = 18093567 },
+    { url = "https://files.pythonhosted.org/packages/d2/b7/a734c733286e10a7f1a8ad1ae8c90f2d33bf604a96548e0a4a3a6739b468/numpy-1.26.4-cp311-cp311-win32.whl", hash = "sha256:1af303d6b2210eb850fcf03064d364652b7120803a0b872f5211f5234b399f20", size = 5968812 },
+    { url = "https://files.pythonhosted.org/packages/3f/6b/5610004206cf7f8e7ad91c5a85a8c71b2f2f8051a0c0c4d5916b76d6cbb2/numpy-1.26.4-cp311-cp311-win_amd64.whl", hash = "sha256:cd25bcecc4974d09257ffcd1f098ee778f7834c3ad767fe5db785be9a4aa9cb2", size = 15811913 },
+    { url = "https://files.pythonhosted.org/packages/95/12/8f2020a8e8b8383ac0177dc9570aad031a3beb12e38847f7129bacd96228/numpy-1.26.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b3ce300f3644fb06443ee2222c2201dd3a89ea6040541412b8fa189341847218", size = 20335901 },
+    { url = "https://files.pythonhosted.org/packages/75/5b/ca6c8bd14007e5ca171c7c03102d17b4f4e0ceb53957e8c44343a9546dcc/numpy-1.26.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:03a8c78d01d9781b28a6989f6fa1bb2c4f2d51201cf99d3dd875df6fbd96b23b", size = 13685868 },
+    { url = "https://files.pythonhosted.org/packages/79/f8/97f10e6755e2a7d027ca783f63044d5b1bc1ae7acb12afe6a9b4286eac17/numpy-1.26.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9fad7dcb1aac3c7f0584a5a8133e3a43eeb2fe127f47e3632d43d677c66c102b", size = 13925109 },
+    { url = "https://files.pythonhosted.org/packages/0f/50/de23fde84e45f5c4fda2488c759b69990fd4512387a8632860f3ac9cd225/numpy-1.26.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:675d61ffbfa78604709862923189bad94014bef562cc35cf61d3a07bba02a7ed", size = 17950613 },
+    { url = "https://files.pythonhosted.org/packages/4c/0c/9c603826b6465e82591e05ca230dfc13376da512b25ccd0894709b054ed0/numpy-1.26.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab47dbe5cc8210f55aa58e4805fe224dac469cde56b9f731a4c098b91917159a", size = 13572172 },
+    { url = "https://files.pythonhosted.org/packages/76/8c/2ba3902e1a0fc1c74962ea9bb33a534bb05984ad7ff9515bf8d07527cadd/numpy-1.26.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1dda2e7b4ec9dd512f84935c5f126c8bd8b9f2fc001e9f54af255e8c5f16b0e0", size = 17786643 },
+    { url = "https://files.pythonhosted.org/packages/28/4a/46d9e65106879492374999e76eb85f87b15328e06bd1550668f79f7b18c6/numpy-1.26.4-cp312-cp312-win32.whl", hash = "sha256:50193e430acfc1346175fcbdaa28ffec49947a06918b7b92130744e81e640110", size = 5677803 },
+    { url = "https://files.pythonhosted.org/packages/16/2e/86f24451c2d530c88daf997cb8d6ac622c1d40d19f5a031ed68a4b73a374/numpy-1.26.4-cp312-cp312-win_amd64.whl", hash = "sha256:08beddf13648eb95f8d867350f6a018a4be2e5ad54c8d8caed89ebca558b2818", size = 15517754 },
+]
+
+[[package]]
+name = "numpy"
+version = "2.2.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform != 'win32'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/90/8956572f5c4ae52201fdec7ba2044b2c882832dcec7d5d0922c9e9acf2de/numpy-2.2.3.tar.gz", hash = "sha256:dbdc15f0c81611925f382dfa97b3bd0bc2c1ce19d4fe50482cb0ddc12ba30020", size = 20262700 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/86/453aa3949eab6ff54e2405f9cb0c01f756f031c3dc2a6d60a1d40cba5488/numpy-2.2.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:16372619ee728ed67a2a606a614f56d3eabc5b86f8b615c79d01957062826ca8", size = 21237256 },
+    { url = "https://files.pythonhosted.org/packages/20/c3/93ecceadf3e155d6a9e4464dd2392d8d80cf436084c714dc8535121c83e8/numpy-2.2.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5521a06a3148686d9269c53b09f7d399a5725c47bbb5b35747e1cb76326b714b", size = 14408049 },
+    { url = "https://files.pythonhosted.org/packages/8d/29/076999b69bd9264b8df5e56f2be18da2de6b2a2d0e10737e5307592e01de/numpy-2.2.3-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:7c8dde0ca2f77828815fd1aedfdf52e59071a5bae30dac3b4da2a335c672149a", size = 5408655 },
+    { url = "https://files.pythonhosted.org/packages/e2/a7/b14f0a73eb0fe77cb9bd5b44534c183b23d4229c099e339c522724b02678/numpy-2.2.3-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:77974aba6c1bc26e3c205c2214f0d5b4305bdc719268b93e768ddb17e3fdd636", size = 6949996 },
+    { url = "https://files.pythonhosted.org/packages/72/2f/8063da0616bb0f414b66dccead503bd96e33e43685c820e78a61a214c098/numpy-2.2.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d42f9c36d06440e34226e8bd65ff065ca0963aeecada587b937011efa02cdc9d", size = 14355789 },
+    { url = "https://files.pythonhosted.org/packages/e6/d7/3cd47b00b8ea95ab358c376cf5602ad21871410950bc754cf3284771f8b6/numpy-2.2.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2712c5179f40af9ddc8f6727f2bd910ea0eb50206daea75f58ddd9fa3f715bb", size = 16411356 },
+    { url = "https://files.pythonhosted.org/packages/27/c0/a2379e202acbb70b85b41483a422c1e697ff7eee74db642ca478de4ba89f/numpy-2.2.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c8b0451d2ec95010d1db8ca733afc41f659f425b7f608af569711097fd6014e2", size = 15576770 },
+    { url = "https://files.pythonhosted.org/packages/bc/63/a13ee650f27b7999e5b9e1964ae942af50bb25606d088df4229283eda779/numpy-2.2.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d9b4a8148c57ecac25a16b0e11798cbe88edf5237b0df99973687dd866f05e1b", size = 18200483 },
+    { url = "https://files.pythonhosted.org/packages/4c/87/e71f89935e09e8161ac9c590c82f66d2321eb163893a94af749dfa8a3cf8/numpy-2.2.3-cp311-cp311-win32.whl", hash = "sha256:1f45315b2dc58d8a3e7754fe4e38b6fce132dab284a92851e41b2b344f6441c5", size = 6588415 },
+    { url = "https://files.pythonhosted.org/packages/b9/c6/cd4298729826af9979c5f9ab02fcaa344b82621e7c49322cd2d210483d3f/numpy-2.2.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f48ba6f6c13e5e49f3d3efb1b51c8193215c42ac82610a04624906a9270be6f", size = 12929604 },
+    { url = "https://files.pythonhosted.org/packages/43/ec/43628dcf98466e087812142eec6d1c1a6c6bdfdad30a0aa07b872dc01f6f/numpy-2.2.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:12c045f43b1d2915eca6b880a7f4a256f59d62df4f044788c8ba67709412128d", size = 20929458 },
+    { url = "https://files.pythonhosted.org/packages/9b/c0/2f4225073e99a5c12350954949ed19b5d4a738f541d33e6f7439e33e98e4/numpy-2.2.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:87eed225fd415bbae787f93a457af7f5990b92a334e346f72070bf569b9c9c95", size = 14115299 },
+    { url = "https://files.pythonhosted.org/packages/ca/fa/d2c5575d9c734a7376cc1592fae50257ec95d061b27ee3dbdb0b3b551eb2/numpy-2.2.3-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:712a64103d97c404e87d4d7c47fb0c7ff9acccc625ca2002848e0d53288b90ea", size = 5145723 },
+    { url = "https://files.pythonhosted.org/packages/eb/dc/023dad5b268a7895e58e791f28dc1c60eb7b6c06fcbc2af8538ad069d5f3/numpy-2.2.3-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:a5ae282abe60a2db0fd407072aff4599c279bcd6e9a2475500fc35b00a57c532", size = 6678797 },
+    { url = "https://files.pythonhosted.org/packages/3f/19/bcd641ccf19ac25abb6fb1dcd7744840c11f9d62519d7057b6ab2096eb60/numpy-2.2.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5266de33d4c3420973cf9ae3b98b54a2a6d53a559310e3236c4b2b06b9c07d4e", size = 14067362 },
+    { url = "https://files.pythonhosted.org/packages/39/04/78d2e7402fb479d893953fb78fa7045f7deb635ec095b6b4f0260223091a/numpy-2.2.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b787adbf04b0db1967798dba8da1af07e387908ed1553a0d6e74c084d1ceafe", size = 16116679 },
+    { url = "https://files.pythonhosted.org/packages/d0/a1/e90f7aa66512be3150cb9d27f3d9995db330ad1b2046474a13b7040dfd92/numpy-2.2.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:34c1b7e83f94f3b564b35f480f5652a47007dd91f7c839f404d03279cc8dd021", size = 15264272 },
+    { url = "https://files.pythonhosted.org/packages/dc/b6/50bd027cca494de4fa1fc7bf1662983d0ba5f256fa0ece2c376b5eb9b3f0/numpy-2.2.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4d8335b5f1b6e2bce120d55fb17064b0262ff29b459e8493d1785c18ae2553b8", size = 17880549 },
+    { url = "https://files.pythonhosted.org/packages/96/30/f7bf4acb5f8db10a96f73896bdeed7a63373137b131ca18bd3dab889db3b/numpy-2.2.3-cp312-cp312-win32.whl", hash = "sha256:4d9828d25fb246bedd31e04c9e75714a4087211ac348cb39c8c5f99dbb6683fe", size = 6293394 },
+    { url = "https://files.pythonhosted.org/packages/42/6e/55580a538116d16ae7c9aa17d4edd56e83f42126cb1dfe7a684da7925d2c/numpy-2.2.3-cp312-cp312-win_amd64.whl", hash = "sha256:83807d445817326b4bcdaaaf8e8e9f1753da04341eceec705c001ff342002e5d", size = 12626357 },
+    { url = "https://files.pythonhosted.org/packages/0e/8b/88b98ed534d6a03ba8cddb316950fe80842885709b58501233c29dfa24a9/numpy-2.2.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7bfdb06b395385ea9b91bf55c1adf1b297c9fdb531552845ff1d3ea6e40d5aba", size = 20916001 },
+    { url = "https://files.pythonhosted.org/packages/d9/b4/def6ec32c725cc5fbd8bdf8af80f616acf075fe752d8a23e895da8c67b70/numpy-2.2.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:23c9f4edbf4c065fddb10a4f6e8b6a244342d95966a48820c614891e5059bb50", size = 14130721 },
+    { url = "https://files.pythonhosted.org/packages/20/60/70af0acc86495b25b672d403e12cb25448d79a2b9658f4fc45e845c397a8/numpy-2.2.3-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:a0c03b6be48aaf92525cccf393265e02773be8fd9551a2f9adbe7db1fa2b60f1", size = 5130999 },
+    { url = "https://files.pythonhosted.org/packages/2e/69/d96c006fb73c9a47bcb3611417cf178049aae159afae47c48bd66df9c536/numpy-2.2.3-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:2376e317111daa0a6739e50f7ee2a6353f768489102308b0d98fcf4a04f7f3b5", size = 6665299 },
+    { url = "https://files.pythonhosted.org/packages/5a/3f/d8a877b6e48103733ac224ffa26b30887dc9944ff95dffdfa6c4ce3d7df3/numpy-2.2.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8fb62fe3d206d72fe1cfe31c4a1106ad2b136fcc1606093aeab314f02930fdf2", size = 14064096 },
+    { url = "https://files.pythonhosted.org/packages/e4/43/619c2c7a0665aafc80efca465ddb1f260287266bdbdce517396f2f145d49/numpy-2.2.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:52659ad2534427dffcc36aac76bebdd02b67e3b7a619ac67543bc9bfe6b7cdb1", size = 16114758 },
+    { url = "https://files.pythonhosted.org/packages/d9/79/ee4fe4f60967ccd3897aa71ae14cdee9e3c097e3256975cc9575d393cb42/numpy-2.2.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1b416af7d0ed3271cad0f0a0d0bee0911ed7eba23e66f8424d9f3dfcdcae1304", size = 15259880 },
+    { url = "https://files.pythonhosted.org/packages/fb/c8/8b55cf05db6d85b7a7d414b3d1bd5a740706df00bfa0824a08bf041e52ee/numpy-2.2.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1402da8e0f435991983d0a9708b779f95a8c98c6b18a171b9f1be09005e64d9d", size = 17876721 },
+    { url = "https://files.pythonhosted.org/packages/21/d6/b4c2f0564b7dcc413117b0ffbb818d837e4b29996b9234e38b2025ed24e7/numpy-2.2.3-cp313-cp313-win32.whl", hash = "sha256:136553f123ee2951bfcfbc264acd34a2fc2f29d7cdf610ce7daf672b6fbaa693", size = 6290195 },
+    { url = "https://files.pythonhosted.org/packages/97/e7/7d55a86719d0de7a6a597949f3febefb1009435b79ba510ff32f05a8c1d7/numpy-2.2.3-cp313-cp313-win_amd64.whl", hash = "sha256:5b732c8beef1d7bc2d9e476dbba20aaff6167bf205ad9aa8d30913859e82884b", size = 12619013 },
+    { url = "https://files.pythonhosted.org/packages/a6/1f/0b863d5528b9048fd486a56e0b97c18bf705e88736c8cea7239012119a54/numpy-2.2.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:435e7a933b9fda8126130b046975a968cc2d833b505475e588339e09f7672890", size = 20944621 },
+    { url = "https://files.pythonhosted.org/packages/aa/99/b478c384f7a0a2e0736177aafc97dc9152fc036a3fdb13f5a3ab225f1494/numpy-2.2.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:7678556eeb0152cbd1522b684dcd215250885993dd00adb93679ec3c0e6e091c", size = 14142502 },
+    { url = "https://files.pythonhosted.org/packages/fb/61/2d9a694a0f9cd0a839501d362de2a18de75e3004576a3008e56bdd60fcdb/numpy-2.2.3-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:2e8da03bd561504d9b20e7a12340870dfc206c64ea59b4cfee9fceb95070ee94", size = 5176293 },
+    { url = "https://files.pythonhosted.org/packages/33/35/51e94011b23e753fa33f891f601e5c1c9a3d515448659b06df9d40c0aa6e/numpy-2.2.3-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:c9aa4496fd0e17e3843399f533d62857cef5900facf93e735ef65aa4bbc90ef0", size = 6691874 },
+    { url = "https://files.pythonhosted.org/packages/ff/cf/06e37619aad98a9d03bd8d65b8e3041c3a639be0f5f6b0a0e2da544538d4/numpy-2.2.3-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f4ca91d61a4bf61b0f2228f24bbfa6a9facd5f8af03759fe2a655c50ae2c6610", size = 14036826 },
+    { url = "https://files.pythonhosted.org/packages/0c/93/5d7d19955abd4d6099ef4a8ee006f9ce258166c38af259f9e5558a172e3e/numpy-2.2.3-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:deaa09cd492e24fd9b15296844c0ad1b3c976da7907e1c1ed3a0ad21dded6f76", size = 16096567 },
+    { url = "https://files.pythonhosted.org/packages/af/53/d1c599acf7732d81f46a93621dab6aa8daad914b502a7a115b3f17288ab2/numpy-2.2.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:246535e2f7496b7ac85deffe932896a3577be7af8fb7eebe7146444680297e9a", size = 15242514 },
+    { url = "https://files.pythonhosted.org/packages/53/43/c0f5411c7b3ea90adf341d05ace762dad8cb9819ef26093e27b15dd121ac/numpy-2.2.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:daf43a3d1ea699402c5a850e5313680ac355b4adc9770cd5cfc2940e7861f1bf", size = 17872920 },
+    { url = "https://files.pythonhosted.org/packages/5b/57/6dbdd45ab277aff62021cafa1e15f9644a52f5b5fc840bc7591b4079fb58/numpy-2.2.3-cp313-cp313t-win32.whl", hash = "sha256:cf802eef1f0134afb81fef94020351be4fe1d6681aadf9c5e862af6602af64ef", size = 6346584 },
+    { url = "https://files.pythonhosted.org/packages/97/9b/484f7d04b537d0a1202a5ba81c6f53f1846ae6c63c2127f8df869ed31342/numpy-2.2.3-cp313-cp313t-win_amd64.whl", hash = "sha256:aee2512827ceb6d7f517c8b85aa5d3923afe8fc7a57d028cffcd522f1c6fd082", size = 12706784 },
+]
+
+[[package]]
+name = "numpy"
 version = "2.2.6"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.13' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+]
 sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/a8/4f83e2aa666a9fbf56d6118faaaf5f1974d456b1823fda0a176eff722839/numpy-2.2.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f9f1adb22318e121c5c69a09142811a201ef17ab257a1e66ca3025065b7f53ae", size = 21176963 },
@@ -1706,59 +2057,273 @@ wheels = [
 
 [[package]]
 name = "nvidia-cublas-cu12"
+version = "12.1.3.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'linux'",
+    "python_full_version < '3.12' and sys_platform == 'linux'",
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/6d/121efd7382d5b0284239f4ab1fc1590d86d34ed4a4a2fdb13b30ca8e5740/nvidia_cublas_cu12-12.1.3.1-py3-none-manylinux1_x86_64.whl", hash = "sha256:ee53ccca76a6fc08fb9701aa95b6ceb242cdaab118c3bb152af4e579af792728", size = 410594774 },
+    { url = "https://files.pythonhosted.org/packages/c5/ef/32a375b74bea706c93deea5613552f7c9104f961b21df423f5887eca713b/nvidia_cublas_cu12-12.1.3.1-py3-none-win_amd64.whl", hash = "sha256:2b964d60e8cf11b5e1073d179d85fa340c120e99b3067558f3cf98dd69d02906", size = 439918445 },
+]
+
+[[package]]
+name = "nvidia-cublas-cu12"
+version = "12.4.5.8"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform != 'win32'",
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/7f/7fbae15a3982dc9595e49ce0f19332423b260045d0a6afe93cdbe2f1f624/nvidia_cublas_cu12-12.4.5.8-py3-none-manylinux2014_aarch64.whl", hash = "sha256:0f8aa1706812e00b9f19dfe0cdb3999b092ccb8ca168c0db5b8ea712456fd9b3", size = 363333771 },
+    { url = "https://files.pythonhosted.org/packages/ae/71/1c91302526c45ab494c23f61c7a84aa568b8c1f9d196efa5993957faf906/nvidia_cublas_cu12-12.4.5.8-py3-none-manylinux2014_x86_64.whl", hash = "sha256:2fc8da60df463fdefa81e323eef2e36489e1c94335b5358bcb38360adf75ac9b", size = 363438805 },
+    { url = "https://files.pythonhosted.org/packages/e2/2a/4f27ca96232e8b5269074a72e03b4e0d43aa68c9b965058b1684d07c6ff8/nvidia_cublas_cu12-12.4.5.8-py3-none-win_amd64.whl", hash = "sha256:5a796786da89203a0657eda402bcdcec6180254a8ac22d72213abc42069522dc", size = 396895858 },
+]
+
+[[package]]
+name = "nvidia-cublas-cu12"
 version = "12.6.4.1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/eb/ff4b8c503fa1f1796679dce648854d58751982426e4e4b37d6fce49d259c/nvidia_cublas_cu12-12.6.4.1-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:08ed2686e9875d01b58e3cb379c6896df8e76c75e0d4a7f7dace3d7b6d9ef8eb", size = 393138322 },
+    { url = "https://files.pythonhosted.org/packages/97/0d/f1f0cadbf69d5b9ef2e4f744c9466cb0a850741d08350736dfdb4aa89569/nvidia_cublas_cu12-12.6.4.1-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:235f728d6e2a409eddf1df58d5b0921cf80cfa9e72b9f2775ccb7b4a87984668", size = 390794615 },
+    { url = "https://files.pythonhosted.org/packages/84/f7/985e9bdbe3e0ac9298fcc8cfa51a392862a46a0ffaccbbd56939b62a9c83/nvidia_cublas_cu12-12.6.4.1-py3-none-win_amd64.whl", hash = "sha256:9e4fa264f4d8a4eb0cdbd34beadc029f453b3bafae02401e999cf3d5a5af75f8", size = 434535301 },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti-cu12"
+version = "12.1.105"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'linux'",
+    "python_full_version < '3.12' and sys_platform == 'linux'",
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/00/6b218edd739ecfc60524e585ba8e6b00554dd908de2c9c66c1af3e44e18d/nvidia_cuda_cupti_cu12-12.1.105-py3-none-manylinux1_x86_64.whl", hash = "sha256:e54fde3983165c624cb79254ae9818a456eb6e87a7fd4d56a2352c24ee542d7e", size = 14109015 },
+    { url = "https://files.pythonhosted.org/packages/d0/56/0021e32ea2848c24242f6b56790bd0ccc8bf99f973ca790569c6ca028107/nvidia_cuda_cupti_cu12-12.1.105-py3-none-win_amd64.whl", hash = "sha256:bea8236d13a0ac7190bd2919c3e8e6ce1e402104276e6f9694479e48bb0eb2a4", size = 10154340 },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti-cu12"
+version = "12.4.127"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform != 'win32'",
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/b5/9fb3d00386d3361b03874246190dfec7b206fd74e6e287b26a8fcb359d95/nvidia_cuda_cupti_cu12-12.4.127-py3-none-manylinux2014_aarch64.whl", hash = "sha256:79279b35cf6f91da114182a5ce1864997fd52294a87a16179ce275773799458a", size = 12354556 },
+    { url = "https://files.pythonhosted.org/packages/67/42/f4f60238e8194a3106d06a058d494b18e006c10bb2b915655bd9f6ea4cb1/nvidia_cuda_cupti_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl", hash = "sha256:9dec60f5ac126f7bb551c055072b69d85392b13311fcc1bcda2202d172df30fb", size = 13813957 },
+    { url = "https://files.pythonhosted.org/packages/f3/79/8cf313ec17c58ccebc965568e5bcb265cdab0a1df99c4e674bb7a3b99bfe/nvidia_cuda_cupti_cu12-12.4.127-py3-none-win_amd64.whl", hash = "sha256:5688d203301ab051449a2b1cb6690fbe90d2b372f411521c86018b950f3d7922", size = 9938035 },
 ]
 
 [[package]]
 name = "nvidia-cuda-cupti-cu12"
 version = "12.6.80"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/8b/2f6230cb715646c3a9425636e513227ce5c93c4d65823a734f4bb86d43c3/nvidia_cuda_cupti_cu12-12.6.80-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:166ee35a3ff1587f2490364f90eeeb8da06cd867bd5b701bf7f9a02b78bc63fc", size = 8236764 },
+    { url = "https://files.pythonhosted.org/packages/25/0f/acb326ac8fd26e13c799e0b4f3b2751543e1834f04d62e729485872198d4/nvidia_cuda_cupti_cu12-12.6.80-py3-none-manylinux2014_aarch64.whl", hash = "sha256:358b4a1d35370353d52e12f0a7d1769fc01ff74a191689d3870b2123156184c4", size = 8236756 },
     { url = "https://files.pythonhosted.org/packages/49/60/7b6497946d74bcf1de852a21824d63baad12cd417db4195fc1bfe59db953/nvidia_cuda_cupti_cu12-12.6.80-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6768bad6cab4f19e8292125e5f1ac8aa7d1718704012a0e3272a6f61c4bce132", size = 8917980 },
     { url = "https://files.pythonhosted.org/packages/a5/24/120ee57b218d9952c379d1e026c4479c9ece9997a4fb46303611ee48f038/nvidia_cuda_cupti_cu12-12.6.80-py3-none-manylinux2014_x86_64.whl", hash = "sha256:a3eff6cdfcc6a4c35db968a06fcadb061cbc7d6dde548609a941ff8701b98b73", size = 8917972 },
+    { url = "https://files.pythonhosted.org/packages/1c/81/7796f096afaf726796b1b648f3bc80cafc61fe7f77f44a483c89e6c5ef34/nvidia_cuda_cupti_cu12-12.6.80-py3-none-win_amd64.whl", hash = "sha256:bbe6ae76e83ce5251b56e8c8e61a964f757175682bbad058b170b136266ab00a", size = 5724175 },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc-cu12"
+version = "12.1.105"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'linux'",
+    "python_full_version < '3.12' and sys_platform == 'linux'",
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/9f/c64c03f49d6fbc56196664d05dba14e3a561038a81a638eeb47f4d4cfd48/nvidia_cuda_nvrtc_cu12-12.1.105-py3-none-manylinux1_x86_64.whl", hash = "sha256:339b385f50c309763ca65456ec75e17bbefcbbf2893f462cb8b90584cd27a1c2", size = 23671734 },
+    { url = "https://files.pythonhosted.org/packages/ad/1d/f76987c4f454eb86e0b9a0e4f57c3bf1ac1d13ad13cd1a4da4eb0e0c0ce9/nvidia_cuda_nvrtc_cu12-12.1.105-py3-none-win_amd64.whl", hash = "sha256:0a98a522d9ff138b96c010a65e145dc1b4850e9ecb75a0172371793752fd46ed", size = 19331863 },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc-cu12"
+version = "12.4.127"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform != 'win32'",
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/aa/083b01c427e963ad0b314040565ea396f914349914c298556484f799e61b/nvidia_cuda_nvrtc_cu12-12.4.127-py3-none-manylinux2014_aarch64.whl", hash = "sha256:0eedf14185e04b76aa05b1fea04133e59f465b6f960c0cbf4e37c3cb6b0ea198", size = 24133372 },
+    { url = "https://files.pythonhosted.org/packages/2c/14/91ae57cd4db3f9ef7aa99f4019cfa8d54cb4caa7e00975df6467e9725a9f/nvidia_cuda_nvrtc_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl", hash = "sha256:a178759ebb095827bd30ef56598ec182b85547f1508941a3d560eb7ea1fbf338", size = 24640306 },
+    { url = "https://files.pythonhosted.org/packages/7c/30/8c844bfb770f045bcd8b2c83455c5afb45983e1a8abf0c4e5297b481b6a5/nvidia_cuda_nvrtc_cu12-12.4.127-py3-none-win_amd64.whl", hash = "sha256:a961b2f1d5f17b14867c619ceb99ef6fcec12e46612711bcec78eb05068a60ec", size = 19751955 },
 ]
 
 [[package]]
 name = "nvidia-cuda-nvrtc-cu12"
 version = "12.6.77"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/2f/72df534873235983cc0a5371c3661bebef7c4682760c275590b972c7b0f9/nvidia_cuda_nvrtc_cu12-12.6.77-py3-none-manylinux2014_aarch64.whl", hash = "sha256:5847f1d6e5b757f1d2b3991a01082a44aad6f10ab3c5c0213fa3e25bddc25a13", size = 23162955 },
     { url = "https://files.pythonhosted.org/packages/75/2e/46030320b5a80661e88039f59060d1790298b4718944a65a7f2aeda3d9e9/nvidia_cuda_nvrtc_cu12-12.6.77-py3-none-manylinux2014_x86_64.whl", hash = "sha256:35b0cc6ee3a9636d5409133e79273ce1f3fd087abb0532d2d2e8fff1fe9efc53", size = 23650380 },
+    { url = "https://files.pythonhosted.org/packages/f5/46/d3a1cdda8bb113c80f43a0a6f3a853356d487b830f3483f92d49ce87fa55/nvidia_cuda_nvrtc_cu12-12.6.77-py3-none-win_amd64.whl", hash = "sha256:f7007dbd914c56bd80ea31bc43e8e149da38f68158f423ba845fc3292684e45a", size = 39026742 },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime-cu12"
+version = "12.1.105"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'linux'",
+    "python_full_version < '3.12' and sys_platform == 'linux'",
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/d5/c68b1d2cdfcc59e72e8a5949a37ddb22ae6cade80cd4a57a84d4c8b55472/nvidia_cuda_runtime_cu12-12.1.105-py3-none-manylinux1_x86_64.whl", hash = "sha256:6e258468ddf5796e25f1dc591a31029fa317d97a0a94ed93468fc86301d61e40", size = 823596 },
+    { url = "https://files.pythonhosted.org/packages/9f/e2/7a2b4b5064af56ea8ea2d8b2776c0f2960d95c88716138806121ae52a9c9/nvidia_cuda_runtime_cu12-12.1.105-py3-none-win_amd64.whl", hash = "sha256:dfb46ef84d73fababab44cf03e3b83f80700d27ca300e537f85f636fac474344", size = 821226 },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime-cu12"
+version = "12.4.127"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform != 'win32'",
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/aa/b656d755f474e2084971e9a297def515938d56b466ab39624012070cb773/nvidia_cuda_runtime_cu12-12.4.127-py3-none-manylinux2014_aarch64.whl", hash = "sha256:961fe0e2e716a2a1d967aab7caee97512f71767f852f67432d572e36cb3a11f3", size = 894177 },
+    { url = "https://files.pythonhosted.org/packages/ea/27/1795d86fe88ef397885f2e580ac37628ed058a92ed2c39dc8eac3adf0619/nvidia_cuda_runtime_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl", hash = "sha256:64403288fa2136ee8e467cdc9c9427e0434110899d07c779f25b5c068934faa5", size = 883737 },
+    { url = "https://files.pythonhosted.org/packages/a8/8b/450e93fab75d85a69b50ea2d5fdd4ff44541e0138db16f9cd90123ef4de4/nvidia_cuda_runtime_cu12-12.4.127-py3-none-win_amd64.whl", hash = "sha256:09c2e35f48359752dfa822c09918211844a3d93c100a715d79b59591130c5e1e", size = 878808 },
 ]
 
 [[package]]
 name = "nvidia-cuda-runtime-cu12"
 version = "12.6.77"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/ea/590b2ac00d772a8abd1c387a92b46486d2679ca6622fd25c18ff76265663/nvidia_cuda_runtime_cu12-12.6.77-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6116fad3e049e04791c0256a9778c16237837c08b27ed8c8401e2e45de8d60cd", size = 908052 },
+    { url = "https://files.pythonhosted.org/packages/b7/3d/159023799677126e20c8fd580cca09eeb28d5c5a624adc7f793b9aa8bbfa/nvidia_cuda_runtime_cu12-12.6.77-py3-none-manylinux2014_aarch64.whl", hash = "sha256:d461264ecb429c84c8879a7153499ddc7b19b5f8d84c204307491989a365588e", size = 908040 },
     { url = "https://files.pythonhosted.org/packages/e1/23/e717c5ac26d26cf39a27fbc076240fad2e3b817e5889d671b67f4f9f49c5/nvidia_cuda_runtime_cu12-12.6.77-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ba3b56a4f896141e25e19ab287cd71e52a6a0f4b29d0d31609f60e3b4d5219b7", size = 897690 },
     { url = "https://files.pythonhosted.org/packages/f0/62/65c05e161eeddbafeca24dc461f47de550d9fa8a7e04eb213e32b55cfd99/nvidia_cuda_runtime_cu12-12.6.77-py3-none-manylinux2014_x86_64.whl", hash = "sha256:a84d15d5e1da416dd4774cb42edf5e954a3e60cc945698dc1d5be02321c44dc8", size = 897678 },
+    { url = "https://files.pythonhosted.org/packages/fa/76/4c80fa138333cc975743fd0687a745fccb30d167f906f13c1c7f9a85e5ea/nvidia_cuda_runtime_cu12-12.6.77-py3-none-win_amd64.whl", hash = "sha256:86c58044c824bf3c173c49a2dbc7a6c8b53cb4e4dca50068be0bf64e9dab3f7f", size = 891773 },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu12"
+version = "9.1.0.70"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform == 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform == 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+]
+dependencies = [
+    { name = "nvidia-cublas-cu12", version = "12.1.3.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-fairchem' or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "nvidia-cublas-cu12", version = "12.4.5.8", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-mace' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/fd/713452cd72343f682b1c7b9321e23829f00b842ceaedcda96e742ea0b0b3/nvidia_cudnn_cu12-9.1.0.70-py3-none-manylinux2014_x86_64.whl", hash = "sha256:165764f44ef8c61fcdfdfdbe769d687e06374059fbb388b6c89ecb0e28793a6f", size = 664752741 },
+    { url = "https://files.pythonhosted.org/packages/3f/d0/f90ee6956a628f9f04bf467932c0a25e5a7e706a684b896593c06c82f460/nvidia_cudnn_cu12-9.1.0.70-py3-none-win_amd64.whl", hash = "sha256:6278562929433d68365a07a4a1546c237ba2849852c0d4b2262a486e805b977a", size = 679925892 },
 ]
 
 [[package]]
 name = "nvidia-cudnn-cu12"
 version = "9.5.1.17"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+]
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cublas-cu12", version = "12.6.4.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'win32'" },
 ]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/93/a201a12d3ec1caa8c6ac34c1c2f9eeb696b886f0c36ff23c638b46603bd0/nvidia_cudnn_cu12-9.5.1.17-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:9fd4584468533c61873e5fda8ca41bac3a38bcb2d12350830c69b0a96a7e4def", size = 570523509 },
     { url = "https://files.pythonhosted.org/packages/2a/78/4535c9c7f859a64781e43c969a3a7e84c54634e319a996d43ef32ce46f83/nvidia_cudnn_cu12-9.5.1.17-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:30ac3869f6db17d170e0e556dd6cc5eee02647abc31ca856634d5a40f82c15b2", size = 570988386 },
+    { url = "https://files.pythonhosted.org/packages/b6/b2/3f60d15f037fa5419d9d7f788b100ef33ea913ae5315c87ca6d6fa606c35/nvidia_cudnn_cu12-9.5.1.17-py3-none-win_amd64.whl", hash = "sha256:d7af0f8a4f3b4b9dbb3122f2ef553b45694ed9c384d5a75bab197b8eefb79ab8", size = 565440743 },
+]
+
+[[package]]
+name = "nvidia-cufft-cu12"
+version = "11.0.2.54"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'linux'",
+    "python_full_version < '3.12' and sys_platform == 'linux'",
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/94/eb540db023ce1d162e7bea9f8f5aa781d57c65aed513c33ee9a5123ead4d/nvidia_cufft_cu12-11.0.2.54-py3-none-manylinux1_x86_64.whl", hash = "sha256:794e3948a1aa71fd817c3775866943936774d1c14e7628c74f6f7417224cdf56", size = 121635161 },
+    { url = "https://files.pythonhosted.org/packages/f7/57/7927a3aa0e19927dfed30256d1c854caf991655d847a4e7c01fe87e3d4ac/nvidia_cufft_cu12-11.0.2.54-py3-none-win_amd64.whl", hash = "sha256:d9ac353f78ff89951da4af698f80870b1534ed69993f10a4cf1d96f21357e253", size = 121344196 },
+]
+
+[[package]]
+name = "nvidia-cufft-cu12"
+version = "11.2.1.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12", version = "12.4.127", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-mace' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/8a/0e728f749baca3fbeffad762738276e5df60851958be7783af121a7221e7/nvidia_cufft_cu12-11.2.1.3-py3-none-manylinux2014_aarch64.whl", hash = "sha256:5dad8008fc7f92f5ddfa2101430917ce2ffacd86824914c82e28990ad7f00399", size = 211422548 },
+    { url = "https://files.pythonhosted.org/packages/27/94/3266821f65b92b3138631e9c8e7fe1fb513804ac934485a8d05776e1dd43/nvidia_cufft_cu12-11.2.1.3-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f083fc24912aa410be21fa16d157fed2055dab1cc4b6934a0e03cba69eb242b9", size = 211459117 },
+    { url = "https://files.pythonhosted.org/packages/f6/ee/3f3f8e9874f0be5bbba8fb4b62b3de050156d159f8b6edc42d6f1074113b/nvidia_cufft_cu12-11.2.1.3-py3-none-win_amd64.whl", hash = "sha256:d802f4954291101186078ccbe22fc285a902136f974d369540fd4a5333d1440b", size = 210576476 },
 ]
 
 [[package]]
 name = "nvidia-cufft-cu12"
 version = "11.3.0.4"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+]
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12", version = "12.6.85", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'win32'" },
 ]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/37/c50d2b2f2c07e146776389e3080f4faf70bcc4fa6e19d65bb54ca174ebc3/nvidia_cufft_cu12-11.3.0.4-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d16079550df460376455cba121db6564089176d9bac9e4f360493ca4741b22a6", size = 200164144 },
+    { url = "https://files.pythonhosted.org/packages/ce/f5/188566814b7339e893f8d210d3a5332352b1409815908dad6a363dcceac1/nvidia_cufft_cu12-11.3.0.4-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8510990de9f96c803a051822618d42bf6cb8f069ff3f48d93a8486efdacb48fb", size = 200164135 },
     { url = "https://files.pythonhosted.org/packages/8f/16/73727675941ab8e6ffd86ca3a4b7b47065edcca7a997920b831f8147c99d/nvidia_cufft_cu12-11.3.0.4-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ccba62eb9cef5559abd5e0d54ceed2d9934030f51163df018532142a8ec533e5", size = 200221632 },
     { url = "https://files.pythonhosted.org/packages/60/de/99ec247a07ea40c969d904fc14f3a356b3e2a704121675b75c366b694ee1/nvidia_cufft_cu12-11.3.0.4-py3-none-manylinux2014_x86_64.whl", hash = "sha256:768160ac89f6f7b459bee747e8d175dbf53619cfe74b2a5636264163138013ca", size = 200221622 },
+    { url = "https://files.pythonhosted.org/packages/b4/38/36fd800cec8f6e89b7c1576edaaf8076e69ec631644cdbc1b5f2e2b5a9df/nvidia_cufft_cu12-11.3.0.4-py3-none-win_amd64.whl", hash = "sha256:6048ebddfb90d09d2707efb1fd78d4e3a77cb3ae4dc60e19aab6be0ece2ae464", size = 199356881 },
 ]
 
 [[package]]
@@ -1767,74 +2332,333 @@ version = "1.11.1.6"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/66/cc9876340ac68ae71b15c743ddb13f8b30d5244af344ec8322b449e35426/nvidia_cufile_cu12-1.11.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc23469d1c7e52ce6c1d55253273d32c565dd22068647f3aa59b3c6b005bf159", size = 1142103 },
+    { url = "https://files.pythonhosted.org/packages/17/bf/cc834147263b929229ce4aadd62869f0b195e98569d4c28b23edc72b85d9/nvidia_cufile_cu12-1.11.1.6-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:8f57a0051dcf2543f6dc2b98a98cb2719c37d3cee1baba8965d57f3bbc90d4db", size = 1066155 },
+]
+
+[[package]]
+name = "nvidia-curand-cu12"
+version = "10.3.2.106"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'linux'",
+    "python_full_version < '3.12' and sys_platform == 'linux'",
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/31/4890b1c9abc496303412947fc7dcea3d14861720642b49e8ceed89636705/nvidia_curand_cu12-10.3.2.106-py3-none-manylinux1_x86_64.whl", hash = "sha256:9d264c5036dde4e64f1de8c50ae753237c12e0b1348738169cd0f8a536c0e1e0", size = 56467784 },
+    { url = "https://files.pythonhosted.org/packages/5c/97/4c9c7c79efcdf5b70374241d48cf03b94ef6707fd18ea0c0f53684931d0b/nvidia_curand_cu12-10.3.2.106-py3-none-win_amd64.whl", hash = "sha256:75b6b0c574c0037839121317e17fd01f8a69fd2ef8e25853d826fec30bdba74a", size = 55995813 },
+]
+
+[[package]]
+name = "nvidia-curand-cu12"
+version = "10.3.5.147"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform != 'win32'",
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/9c/a79180e4d70995fdf030c6946991d0171555c6edf95c265c6b2bf7011112/nvidia_curand_cu12-10.3.5.147-py3-none-manylinux2014_aarch64.whl", hash = "sha256:1f173f09e3e3c76ab084aba0de819c49e56614feae5c12f69883f4ae9bb5fad9", size = 56314811 },
+    { url = "https://files.pythonhosted.org/packages/8a/6d/44ad094874c6f1b9c654f8ed939590bdc408349f137f9b98a3a23ccec411/nvidia_curand_cu12-10.3.5.147-py3-none-manylinux2014_x86_64.whl", hash = "sha256:a88f583d4e0bb643c49743469964103aa59f7f708d862c3ddb0fc07f851e3b8b", size = 56305206 },
+    { url = "https://files.pythonhosted.org/packages/1c/22/2573503d0d4e45673c263a313f79410e110eb562636b0617856fdb2ff5f6/nvidia_curand_cu12-10.3.5.147-py3-none-win_amd64.whl", hash = "sha256:f307cc191f96efe9e8f05a87096abc20d08845a841889ef78cb06924437f6771", size = 55799918 },
 ]
 
 [[package]]
 name = "nvidia-curand-cu12"
 version = "10.3.7.77"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/ac/36543605358a355632f1a6faa3e2d5dfb91eab1e4bc7d552040e0383c335/nvidia_curand_cu12-10.3.7.77-py3-none-manylinux2014_aarch64.whl", hash = "sha256:6e82df077060ea28e37f48a3ec442a8f47690c7499bff392a5938614b56c98d8", size = 56289881 },
     { url = "https://files.pythonhosted.org/packages/73/1b/44a01c4e70933637c93e6e1a8063d1e998b50213a6b65ac5a9169c47e98e/nvidia_curand_cu12-10.3.7.77-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a42cd1344297f70b9e39a1e4f467a4e1c10f1da54ff7a85c12197f6c652c8bdf", size = 56279010 },
     { url = "https://files.pythonhosted.org/packages/4a/aa/2c7ff0b5ee02eaef890c0ce7d4f74bc30901871c5e45dee1ae6d0083cd80/nvidia_curand_cu12-10.3.7.77-py3-none-manylinux2014_x86_64.whl", hash = "sha256:99f1a32f1ac2bd134897fc7a203f779303261268a65762a623bf30cc9fe79117", size = 56279000 },
+    { url = "https://files.pythonhosted.org/packages/a6/02/5362a9396f23f7de1dd8a64369e87c85ffff8216fc8194ace0fa45ba27a5/nvidia_curand_cu12-10.3.7.77-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:7b2ed8e95595c3591d984ea3603dd66fe6ce6812b886d59049988a712ed06b6e", size = 56289882 },
+    { url = "https://files.pythonhosted.org/packages/a9/a8/0cd0cec757bd4b4b4ef150fca62ec064db7d08a291dced835a0be7d2c147/nvidia_curand_cu12-10.3.7.77-py3-none-win_amd64.whl", hash = "sha256:6d6d935ffba0f3d439b7cd968192ff068fafd9018dbf1b85b37261b13cfc9905", size = 55783873 },
+]
+
+[[package]]
+name = "nvidia-cusolver-cu12"
+version = "11.4.5.107"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'linux'",
+    "python_full_version < '3.12' and sys_platform == 'linux'",
+]
+dependencies = [
+    { name = "nvidia-cublas-cu12", version = "12.1.3.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-fairchem' or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "nvidia-cusparse-cu12", version = "12.1.0.106", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-fairchem' or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "nvidia-nvjitlink-cu12", version = "12.6.85", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-fairchem' or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/1d/8de1e5c67099015c834315e333911273a8c6aaba78923dd1d1e25fc5f217/nvidia_cusolver_cu12-11.4.5.107-py3-none-manylinux1_x86_64.whl", hash = "sha256:8a7ec542f0412294b15072fa7dab71d31334014a69f953004ea7a118206fe0dd", size = 124161928 },
+    { url = "https://files.pythonhosted.org/packages/b8/80/8fca0bf819122a631c3976b6fc517c1b10741b643b94046bd8dd451522c5/nvidia_cusolver_cu12-11.4.5.107-py3-none-win_amd64.whl", hash = "sha256:74e0c3a24c78612192a74fcd90dd117f1cf21dea4822e66d89e8ea80e3cd2da5", size = 121643081 },
+]
+
+[[package]]
+name = "nvidia-cusolver-cu12"
+version = "11.6.1.9"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "nvidia-cublas-cu12", version = "12.4.5.8", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-mace' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "nvidia-cusparse-cu12", version = "12.3.1.170", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-mace' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "nvidia-nvjitlink-cu12", version = "12.4.127", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-mace' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/6b/a5c33cf16af09166845345275c34ad2190944bcc6026797a39f8e0a282e0/nvidia_cusolver_cu12-11.6.1.9-py3-none-manylinux2014_aarch64.whl", hash = "sha256:d338f155f174f90724bbde3758b7ac375a70ce8e706d70b018dd3375545fc84e", size = 127634111 },
+    { url = "https://files.pythonhosted.org/packages/3a/e1/5b9089a4b2a4790dfdea8b3a006052cfecff58139d5a4e34cb1a51df8d6f/nvidia_cusolver_cu12-11.6.1.9-py3-none-manylinux2014_x86_64.whl", hash = "sha256:19e33fa442bcfd085b3086c4ebf7e8debc07cfe01e11513cc6d332fd918ac260", size = 127936057 },
+    { url = "https://files.pythonhosted.org/packages/f2/be/d435b7b020e854d5d5a682eb5de4328fd62f6182507406f2818280e206e2/nvidia_cusolver_cu12-11.6.1.9-py3-none-win_amd64.whl", hash = "sha256:e77314c9d7b694fcebc84f58989f3aa4fb4cb442f12ca1a9bde50f5e8f6d1b9c", size = 125224015 },
 ]
 
 [[package]]
 name = "nvidia-cusolver-cu12"
 version = "11.7.1.2"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+]
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'win32'" },
-    { name = "nvidia-cusparse-cu12", marker = "sys_platform != 'win32'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cublas-cu12", version = "12.6.4.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cusparse-cu12", version = "12.5.4.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12", version = "12.6.85", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'win32'" },
 ]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/17/dbe1aa865e4fdc7b6d4d0dd308fdd5aaab60f939abfc0ea1954eac4fb113/nvidia_cusolver_cu12-11.7.1.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:0ce237ef60acde1efc457335a2ddadfd7610b892d94efee7b776c64bb1cac9e0", size = 157833628 },
     { url = "https://files.pythonhosted.org/packages/f0/6e/c2cf12c9ff8b872e92b4a5740701e51ff17689c4d726fca91875b07f655d/nvidia_cusolver_cu12-11.7.1.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e9e49843a7707e42022babb9bcfa33c29857a93b88020c4e4434656a655b698c", size = 158229790 },
     { url = "https://files.pythonhosted.org/packages/9f/81/baba53585da791d043c10084cf9553e074548408e04ae884cfe9193bd484/nvidia_cusolver_cu12-11.7.1.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:6cf28f17f64107a0c4d7802be5ff5537b2130bfc112f25d5a30df227058ca0e6", size = 158229780 },
+    { url = "https://files.pythonhosted.org/packages/7c/5f/07d0ba3b7f19be5a5ec32a8679fc9384cfd9fc6c869825e93be9f28d6690/nvidia_cusolver_cu12-11.7.1.2-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:dbbe4fc38ec1289c7e5230e16248365e375c3673c9c8bac5796e2e20db07f56e", size = 157833630 },
+    { url = "https://files.pythonhosted.org/packages/d4/53/fff50a0808df7113d77e3bbc7c2b7eaed6f57d5eb80fbe93ead2aea1e09a/nvidia_cusolver_cu12-11.7.1.2-py3-none-win_amd64.whl", hash = "sha256:6813f9d8073f555444a8705f3ab0296d3e1cb37a16d694c5fc8b862a0d8706d7", size = 149287877 },
+]
+
+[[package]]
+name = "nvidia-cusparse-cu12"
+version = "12.1.0.106"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'linux'",
+    "python_full_version < '3.12' and sys_platform == 'linux'",
+]
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12", version = "12.6.85", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-fairchem' or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/5b/cfaeebf25cd9fdec14338ccb16f6b2c4c7fa9163aefcf057d86b9cc248bb/nvidia_cusparse_cu12-12.1.0.106-py3-none-manylinux1_x86_64.whl", hash = "sha256:f3b50f42cf363f86ab21f720998517a659a48131e8d538dc02f8768237bd884c", size = 195958278 },
+    { url = "https://files.pythonhosted.org/packages/0f/95/48fdbba24c93614d1ecd35bc6bdc6087bd17cbacc3abc4b05a9c2a1ca232/nvidia_cusparse_cu12-12.1.0.106-py3-none-win_amd64.whl", hash = "sha256:b798237e81b9719373e8fae8d4f091b70a0cf09d9d85c95a557e11df2d8e9a5a", size = 195414588 },
+]
+
+[[package]]
+name = "nvidia-cusparse-cu12"
+version = "12.3.1.170"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12", version = "12.4.127", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-mace' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/a9/c0d2f83a53d40a4a41be14cea6a0bf9e668ffcf8b004bd65633f433050c0/nvidia_cusparse_cu12-12.3.1.170-py3-none-manylinux2014_aarch64.whl", hash = "sha256:9d32f62896231ebe0480efd8a7f702e143c98cfaa0e8a76df3386c1ba2b54df3", size = 207381987 },
+    { url = "https://files.pythonhosted.org/packages/db/f7/97a9ea26ed4bbbfc2d470994b8b4f338ef663be97b8f677519ac195e113d/nvidia_cusparse_cu12-12.3.1.170-py3-none-manylinux2014_x86_64.whl", hash = "sha256:ea4f11a2904e2a8dc4b1833cc1b5181cde564edd0d5cd33e3c168eff2d1863f1", size = 207454763 },
+    { url = "https://files.pythonhosted.org/packages/a2/e0/3155ca539760a8118ec94cc279b34293309bcd14011fc724f87f31988843/nvidia_cusparse_cu12-12.3.1.170-py3-none-win_amd64.whl", hash = "sha256:9bc90fb087bc7b4c15641521f31c0371e9a612fc2ba12c338d3ae032e6b6797f", size = 204684315 },
 ]
 
 [[package]]
 name = "nvidia-cusparse-cu12"
 version = "12.5.4.2"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+]
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12", version = "12.6.85", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'win32'" },
 ]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/eb/6681efd0aa7df96b4f8067b3ce7246833dd36830bb4cec8896182773db7d/nvidia_cusparse_cu12-12.5.4.2-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d25b62fb18751758fe3c93a4a08eff08effedfe4edf1c6bb5afd0890fe88f887", size = 216451147 },
+    { url = "https://files.pythonhosted.org/packages/d3/56/3af21e43014eb40134dea004e8d0f1ef19d9596a39e4d497d5a7de01669f/nvidia_cusparse_cu12-12.5.4.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7aa32fa5470cf754f72d1116c7cbc300b4e638d3ae5304cfa4a638a5b87161b1", size = 216451135 },
     { url = "https://files.pythonhosted.org/packages/06/1e/b8b7c2f4099a37b96af5c9bb158632ea9e5d9d27d7391d7eb8fc45236674/nvidia_cusparse_cu12-12.5.4.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7556d9eca156e18184b94947ade0fba5bb47d69cec46bf8660fd2c71a4b48b73", size = 216561367 },
     { url = "https://files.pythonhosted.org/packages/43/ac/64c4316ba163e8217a99680c7605f779accffc6a4bcd0c778c12948d3707/nvidia_cusparse_cu12-12.5.4.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:23749a6571191a215cb74d1cdbff4a86e7b19f1200c071b3fcf844a5bea23a2f", size = 216561357 },
+    { url = "https://files.pythonhosted.org/packages/45/ef/876ad8e4260e1128e6d4aac803d9d51baf3791ebdb4a9b8d9b8db032b4b0/nvidia_cusparse_cu12-12.5.4.2-py3-none-win_amd64.whl", hash = "sha256:4acb8c08855a26d737398cba8fb6f8f5045d93f82612b4cfd84645a2332ccf20", size = 213712630 },
+]
+
+[[package]]
+name = "nvidia-cusparselt-cu12"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform != 'win32'",
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/8e/675498726c605c9441cf46653bd29cb1b8666da1fb1469ffa25f67f20c58/nvidia_cusparselt_cu12-0.6.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:067a7f6d03ea0d4841c85f0c6f1991c5dda98211f6302cb83a4ab234ee95bef8", size = 149422781 },
+    { url = "https://files.pythonhosted.org/packages/78/a8/bcbb63b53a4b1234feeafb65544ee55495e1bb37ec31b999b963cbccfd1d/nvidia_cusparselt_cu12-0.6.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:df2c24502fd76ebafe7457dbc4716b2fec071aabaed4fb7691a201cde03704d9", size = 150057751 },
+    { url = "https://files.pythonhosted.org/packages/56/8f/2c33082238b6c5e783a877dc8786ab62619e3e6171c083bd3bba6e3fe75e/nvidia_cusparselt_cu12-0.6.2-py3-none-win_amd64.whl", hash = "sha256:0057c91d230703924c0422feabe4ce768841f9b4b44d28586b6f6d2eb86fbe70", size = 148755794 },
 ]
 
 [[package]]
 name = "nvidia-cusparselt-cu12"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/da/4de092c61c6dea1fc9c936e69308a02531d122e12f1f649825934ad651b5/nvidia_cusparselt_cu12-0.6.3-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8371549623ba601a06322af2133c4a44350575f5a3108fb75f3ef20b822ad5f1", size = 156402859 },
     { url = "https://files.pythonhosted.org/packages/3b/9a/72ef35b399b0e183bc2e8f6f558036922d453c4d8237dab26c666a04244b/nvidia_cusparselt_cu12-0.6.3-py3-none-manylinux2014_x86_64.whl", hash = "sha256:e5c8a26c36445dd2e6812f1177978a24e2d37cacce7e090f297a688d1ec44f46", size = 156785796 },
+    { url = "https://files.pythonhosted.org/packages/46/3e/9e1e394a02a06f694be2c97bbe47288bb7c90ea84c7e9cf88f7b28afe165/nvidia_cusparselt_cu12-0.6.3-py3-none-win_amd64.whl", hash = "sha256:3b325bcbd9b754ba43df5a311488fca11a6b5dc3d11df4d190c000cf1a0765c7", size = 155595972 },
+]
+
+[[package]]
+name = "nvidia-nccl-cu12"
+version = "2.20.5"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'linux'",
+    "python_full_version < '3.12' and sys_platform == 'linux'",
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/bb/d09dda47c881f9ff504afd6f9ca4f502ded6d8fc2f572cacc5e39da91c28/nvidia_nccl_cu12-2.20.5-py3-none-manylinux2014_aarch64.whl", hash = "sha256:1fc150d5c3250b170b29410ba682384b14581db722b2531b0d8d33c595f33d01", size = 176238458 },
+    { url = "https://files.pythonhosted.org/packages/4b/2a/0a131f572aa09f741c30ccd45a8e56316e8be8dfc7bc19bf0ab7cfef7b19/nvidia_nccl_cu12-2.20.5-py3-none-manylinux2014_x86_64.whl", hash = "sha256:057f6bf9685f75215d0c53bf3ac4a10b3e6578351de307abad9e18a99182af56", size = 176249402 },
+]
+
+[[package]]
+name = "nvidia-nccl-cu12"
+version = "2.21.5"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform != 'win32'",
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/99/12cd266d6233f47d00daf3a72739872bdc10267d0383508b0b9c84a18bb6/nvidia_nccl_cu12-2.21.5-py3-none-manylinux2014_x86_64.whl", hash = "sha256:8579076d30a8c24988834445f8d633c697d42397e92ffc3f63fa26766d25e0a0", size = 188654414 },
 ]
 
 [[package]]
 name = "nvidia-nccl-cu12"
 version = "2.26.2"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/5b/ca2f213f637305633814ae8c36b153220e40a07ea001966dcd87391f3acb/nvidia_nccl_cu12-2.26.2-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c196e95e832ad30fbbb50381eb3cbd1fadd5675e587a548563993609af19522", size = 291671495 },
     { url = "https://files.pythonhosted.org/packages/67/ca/f42388aed0fddd64ade7493dbba36e1f534d4e6fdbdd355c6a90030ae028/nvidia_nccl_cu12-2.26.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:694cf3879a206553cc9d7dbda76b13efaf610fdb70a50cba303de1b0d1530ac6", size = 201319755 },
+]
+
+[[package]]
+name = "nvidia-nvjitlink-cu12"
+version = "12.4.127"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform != 'win32'",
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/45/239d52c05074898a80a900f49b1615d81c07fceadd5ad6c4f86a987c0bc4/nvidia_nvjitlink_cu12-12.4.127-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4abe7fef64914ccfa909bc2ba39739670ecc9e820c83ccc7a6ed414122599b83", size = 20552510 },
+    { url = "https://files.pythonhosted.org/packages/ff/ff/847841bacfbefc97a00036e0fce5a0f086b640756dc38caea5e1bb002655/nvidia_nvjitlink_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl", hash = "sha256:06b3b9b25bf3f8af351d664978ca26a16d2c5127dbd53c0497e28d1fb9611d57", size = 21066810 },
+    { url = "https://files.pythonhosted.org/packages/81/19/0babc919031bee42620257b9a911c528f05fb2688520dcd9ca59159ffea8/nvidia_nvjitlink_cu12-12.4.127-py3-none-win_amd64.whl", hash = "sha256:fd9020c501d27d135f983c6d3e244b197a7ccad769e34df53a42e276b0e25fa1", size = 95336325 },
 ]
 
 [[package]]
 name = "nvidia-nvjitlink-cu12"
 version = "12.6.85"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform == 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform == 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/d7/c5383e47c7e9bf1c99d5bd2a8c935af2b6d705ad831a7ec5c97db4d82f4f/nvidia_nvjitlink_cu12-12.6.85-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:eedc36df9e88b682efe4309aa16b5b4e78c2407eac59e8c10a6a47535164369a", size = 19744971 },
+    { url = "https://files.pythonhosted.org/packages/31/db/dc71113d441f208cdfe7ae10d4983884e13f464a6252450693365e166dcf/nvidia_nvjitlink_cu12-12.6.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cf4eaa7d4b6b543ffd69d6abfb11efdeb2db48270d94dfd3a452c24150829e41", size = 19270338 },
+    { url = "https://files.pythonhosted.org/packages/89/76/93c1467b1387387440a4d25102d86b7794535449b689f8e2dc22c1c8ff7f/nvidia_nvjitlink_cu12-12.6.85-py3-none-win_amd64.whl", hash = "sha256:e61120e52ed675747825cdd16febc6a0730537451d867ee58bee3853b1b13d1c", size = 161908572 },
+]
+
+[[package]]
+name = "nvidia-nvtx-cu12"
+version = "12.1.105"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'linux'",
+    "python_full_version < '3.12' and sys_platform == 'linux'",
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/d3/8057f0587683ed2fcd4dbfbdfdfa807b9160b809976099d36b8f60d08f03/nvidia_nvtx_cu12-12.1.105-py3-none-manylinux1_x86_64.whl", hash = "sha256:dc21cf308ca5691e7c04d962e213f8a4aa9bbfa23d95412f452254c2caeb09e5", size = 99138 },
+    { url = "https://files.pythonhosted.org/packages/b8/d7/bd7cb2d95ac6ac6e8d05bfa96cdce69619f1ef2808e072919044c2d47a8c/nvidia_nvtx_cu12-12.1.105-py3-none-win_amd64.whl", hash = "sha256:65f4d98982b31b60026e0e6de73fbdfc09d08a96f4656dd3665ca616a11e1e82", size = 66307 },
+]
+
+[[package]]
+name = "nvidia-nvtx-cu12"
+version = "12.4.127"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform != 'win32'",
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/39/471f581edbb7804b39e8063d92fc8305bdc7a80ae5c07dbe6ea5c50d14a5/nvidia_nvtx_cu12-12.4.127-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7959ad635db13edf4fc65c06a6e9f9e55fc2f92596db928d169c0bb031e88ef3", size = 100417 },
+    { url = "https://files.pythonhosted.org/packages/87/20/199b8713428322a2f22b722c62b8cc278cc53dffa9705d744484b5035ee9/nvidia_nvtx_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl", hash = "sha256:781e950d9b9f60d8241ccea575b32f5105a5baf4c2351cab5256a24869f12a1a", size = 99144 },
+    { url = "https://files.pythonhosted.org/packages/54/1b/f77674fbb73af98843be25803bbd3b9a4f0a96c75b8d33a2854a5c7d2d77/nvidia_nvtx_cu12-12.4.127-py3-none-win_amd64.whl", hash = "sha256:641dccaaa1139f3ffb0d3164b4b84f9d253397e38246a4f2f36728b48566d485", size = 66307 },
 ]
 
 [[package]]
 name = "nvidia-nvtx-cu12"
 version = "12.6.77"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/93/80f8a520375af9d7ee44571a6544653a176e53c2b8ccce85b97b83c2491b/nvidia_nvtx_cu12-12.6.77-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f44f8d86bb7d5629988d61c8d3ae61dddb2015dee142740536bc7481b022fe4b", size = 90549 },
+    { url = "https://files.pythonhosted.org/packages/2b/53/36e2fd6c7068997169b49ffc8c12d5af5e5ff209df6e1a2c4d373b3a638f/nvidia_nvtx_cu12-12.6.77-py3-none-manylinux2014_aarch64.whl", hash = "sha256:adcaabb9d436c9761fca2b13959a2d237c5f9fd406c8e4b723c695409ff88059", size = 90539 },
     { url = "https://files.pythonhosted.org/packages/56/9a/fff8376f8e3d084cd1530e1ef7b879bb7d6d265620c95c1b322725c694f4/nvidia_nvtx_cu12-12.6.77-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b90bed3df379fa79afbd21be8e04a0314336b8ae16768b58f2d34cb1d04cd7d2", size = 89276 },
     { url = "https://files.pythonhosted.org/packages/9e/4e/0d0c945463719429b7bd21dece907ad0bde437a2ff12b9b12fee94722ab0/nvidia_nvtx_cu12-12.6.77-py3-none-manylinux2014_x86_64.whl", hash = "sha256:6574241a3ec5fdc9334353ab8c479fe75841dbe8f4532a8fc97ce63503330ba1", size = 89265 },
+    { url = "https://files.pythonhosted.org/packages/f7/cd/98a447919d4ed14d407ac82b14b0a0c9c1dbfe81099934b1fc3bfd1e6316/nvidia_nvtx_cu12-12.6.77-py3-none-win_amd64.whl", hash = "sha256:2fb11a4af04a5e6c84073e6404d26588a34afd35379f0855a99797897efa75c0", size = 56434 },
+]
+
+[[package]]
+name = "omegaconf"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "antlr4-python3-runtime" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/48/6388f1bb9da707110532cb70ec4d2822858ddfb44f1cdf1233c20a80ea4b/omegaconf-2.3.0.tar.gz", hash = "sha256:d5d4b6d29955cc50ad50c46dc269bcd92c6e00f5f90d23ab5fee7bfca4ba4cc7", size = 3298120 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/94/1843518e420fa3ed6919835845df698c7e27e183cb997394e4a670973a65/omegaconf-2.3.0-py3-none-any.whl", hash = "sha256:7b4df175cdb08ba400f45cae3bdcae7ba8365db4d165fc65fd04b050ab63b46b", size = 79500 },
 ]
 
 [[package]]
@@ -1853,7 +2677,8 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opt-einsum" },
     { name = "packaging" },
-    { name = "torch" },
+    { name = "torch", version = "2.4.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-fairchem' or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "torch", version = "2.6.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-mace' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/93/de/856dab99be0360c7275fee075eb0450a2ec82a54c4c33689606f62e9615b/opt_einsum_fx-0.1.4.tar.gz", hash = "sha256:7eeb7f91ecb70be65e6179c106ea7f64fc1db6319e3d1289a4518b384f81e74f", size = 12969 }
 wheels = [
@@ -1868,9 +2693,9 @@ dependencies = [
     { name = "ase" },
     { name = "cached-path" },
     { name = "dm-tree" },
-    { name = "numpy" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
     { name = "scipy" },
-    { name = "torch" },
+    { name = "torch", version = "2.7.1", source = { registry = "https://pypi.org/simple" } },
     { name = "tqdm" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ec/63/385c78f164a8062fac89ef631a414463a6029d310d78cff9ee949ef2a9cd/orb_models-0.5.4.tar.gz", hash = "sha256:bc4e7b11eac16e9b1681cb667ccbdd263edf9702433a1eb106969dcc29ce7916", size = 87763 }
@@ -1954,7 +2779,9 @@ name = "pandas"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-fairchem' or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "numpy", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-mace' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-orb' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace')" },
     { name = "python-dateutil" },
     { name = "pytz" },
     { name = "tzdata" },
@@ -2004,7 +2831,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
+    { name = "ptyprocess", marker = "sys_platform != 'win32' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb') or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450 }
 wheels = [
@@ -2250,6 +3077,21 @@ wheels = [
 ]
 
 [[package]]
+name = "psutil"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/80/336820c1ad9286a4ded7e845b2eccfcb27851ab8ac6abece774a6ff4d3de/psutil-7.0.0.tar.gz", hash = "sha256:7be9c3eba38beccb6495ea33afd982a44074b78f28c434a1f51cc07fd315c456", size = 497003 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/e6/2d26234410f8b8abdbf891c9da62bee396583f713fb9f3325a4760875d22/psutil-7.0.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:101d71dc322e3cffd7cea0650b09b3d08b8e7c4109dd6809fe452dfd00e58b25", size = 238051 },
+    { url = "https://files.pythonhosted.org/packages/04/8b/30f930733afe425e3cbfc0e1468a30a18942350c1a8816acfade80c005c4/psutil-7.0.0-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:39db632f6bb862eeccf56660871433e111b6ea58f2caea825571951d4b6aa3da", size = 239535 },
+    { url = "https://files.pythonhosted.org/packages/2a/ed/d362e84620dd22876b55389248e522338ed1bf134a5edd3b8231d7207f6d/psutil-7.0.0-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1fcee592b4c6f146991ca55919ea3d1f8926497a713ed7faaf8225e174581e91", size = 275004 },
+    { url = "https://files.pythonhosted.org/packages/bf/b9/b0eb3f3cbcb734d930fdf839431606844a825b23eaf9a6ab371edac8162c/psutil-7.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b1388a4f6875d7e2aff5c4ca1cc16c545ed41dd8bb596cefea80111db353a34", size = 277986 },
+    { url = "https://files.pythonhosted.org/packages/eb/a2/709e0fe2f093556c17fbafda93ac032257242cabcc7ff3369e2cb76a97aa/psutil-7.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5f098451abc2828f7dc6b58d44b532b22f2088f4999a937557b603ce72b1993", size = 279544 },
+    { url = "https://files.pythonhosted.org/packages/50/e6/eecf58810b9d12e6427369784efe814a1eec0f492084ce8eb8f4d89d6d61/psutil-7.0.0-cp37-abi3-win32.whl", hash = "sha256:ba3fcef7523064a6c9da440fc4d6bd07da93ac726b5733c29027d7dc95b39d99", size = 241053 },
+    { url = "https://files.pythonhosted.org/packages/50/1b/6921afe68c74868b4c9fa424dad3be35b095e16687989ebbb50ce4fceb7c/psutil-7.0.0-cp37-abi3-win_amd64.whl", hash = "sha256:4cf3d4eb1aa9b348dec30105c55cd9b7d4629285735a102beb4441e38db90553", size = 244885 },
+]
+
+[[package]]
 name = "ptyprocess"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2333,6 +3175,97 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.11.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/dd/4325abf92c39ba8623b5af936ddb36ffcfe0beae70405d456ab1fb2f5b8c/pydantic-2.11.7.tar.gz", hash = "sha256:d989c3c6cb79469287b1569f7447a17848c998458d49ebe294e975b9baf0f0db", size = 788350 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/c0/ec2b1c8712ca690e5d61979dee872603e92b8a32f94cc1b72d53beab008a/pydantic-2.11.7-py3-none-any.whl", hash = "sha256:dde5df002701f6de26248661f6835bbe296a47bf73990135c7d07ce741b9623b", size = 444782 },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.33.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/88/5f2260bdfae97aabf98f1778d43f69574390ad787afb646292a638c923d4/pydantic_core-2.33.2.tar.gz", hash = "sha256:7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc", size = 435195 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/8d/71db63483d518cbbf290261a1fc2839d17ff89fce7089e08cad07ccfce67/pydantic_core-2.33.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:4c5b0a576fb381edd6d27f0a85915c6daf2f8138dc5c267a57c08a62900758c7", size = 2028584 },
+    { url = "https://files.pythonhosted.org/packages/24/2f/3cfa7244ae292dd850989f328722d2aef313f74ffc471184dc509e1e4e5a/pydantic_core-2.33.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e799c050df38a639db758c617ec771fd8fb7a5f8eaaa4b27b101f266b216a246", size = 1855071 },
+    { url = "https://files.pythonhosted.org/packages/b3/d3/4ae42d33f5e3f50dd467761304be2fa0a9417fbf09735bc2cce003480f2a/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dc46a01bf8d62f227d5ecee74178ffc448ff4e5197c756331f71efcc66dc980f", size = 1897823 },
+    { url = "https://files.pythonhosted.org/packages/f4/f3/aa5976e8352b7695ff808599794b1fba2a9ae2ee954a3426855935799488/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a144d4f717285c6d9234a66778059f33a89096dfb9b39117663fd8413d582dcc", size = 1983792 },
+    { url = "https://files.pythonhosted.org/packages/d5/7a/cda9b5a23c552037717f2b2a5257e9b2bfe45e687386df9591eff7b46d28/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:73cf6373c21bc80b2e0dc88444f41ae60b2f070ed02095754eb5a01df12256de", size = 2136338 },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/b8f9ec8dd1417eb9da784e91e1667d58a2a4a7b7b34cf4af765ef663a7e5/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3dc625f4aa79713512d1976fe9f0bc99f706a9dee21dfd1810b4bbbf228d0e8a", size = 2730998 },
+    { url = "https://files.pythonhosted.org/packages/47/bc/cd720e078576bdb8255d5032c5d63ee5c0bf4b7173dd955185a1d658c456/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:881b21b5549499972441da4758d662aeea93f1923f953e9cbaff14b8b9565aef", size = 2003200 },
+    { url = "https://files.pythonhosted.org/packages/ca/22/3602b895ee2cd29d11a2b349372446ae9727c32e78a94b3d588a40fdf187/pydantic_core-2.33.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:bdc25f3681f7b78572699569514036afe3c243bc3059d3942624e936ec93450e", size = 2113890 },
+    { url = "https://files.pythonhosted.org/packages/ff/e6/e3c5908c03cf00d629eb38393a98fccc38ee0ce8ecce32f69fc7d7b558a7/pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:fe5b32187cbc0c862ee201ad66c30cf218e5ed468ec8dc1cf49dec66e160cc4d", size = 2073359 },
+    { url = "https://files.pythonhosted.org/packages/12/e7/6a36a07c59ebefc8777d1ffdaf5ae71b06b21952582e4b07eba88a421c79/pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:bc7aee6f634a6f4a95676fcb5d6559a2c2a390330098dba5e5a5f28a2e4ada30", size = 2245883 },
+    { url = "https://files.pythonhosted.org/packages/16/3f/59b3187aaa6cc0c1e6616e8045b284de2b6a87b027cce2ffcea073adf1d2/pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:235f45e5dbcccf6bd99f9f472858849f73d11120d76ea8707115415f8e5ebebf", size = 2241074 },
+    { url = "https://files.pythonhosted.org/packages/e0/ed/55532bb88f674d5d8f67ab121a2a13c385df382de2a1677f30ad385f7438/pydantic_core-2.33.2-cp311-cp311-win32.whl", hash = "sha256:6368900c2d3ef09b69cb0b913f9f8263b03786e5b2a387706c5afb66800efd51", size = 1910538 },
+    { url = "https://files.pythonhosted.org/packages/fe/1b/25b7cccd4519c0b23c2dd636ad39d381abf113085ce4f7bec2b0dc755eb1/pydantic_core-2.33.2-cp311-cp311-win_amd64.whl", hash = "sha256:1e063337ef9e9820c77acc768546325ebe04ee38b08703244c1309cccc4f1bab", size = 1952909 },
+    { url = "https://files.pythonhosted.org/packages/49/a9/d809358e49126438055884c4366a1f6227f0f84f635a9014e2deb9b9de54/pydantic_core-2.33.2-cp311-cp311-win_arm64.whl", hash = "sha256:6b99022f1d19bc32a4c2a0d544fc9a76e3be90f0b3f4af413f87d38749300e65", size = 1897786 },
+    { url = "https://files.pythonhosted.org/packages/18/8a/2b41c97f554ec8c71f2a8a5f85cb56a8b0956addfe8b0efb5b3d77e8bdc3/pydantic_core-2.33.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a7ec89dc587667f22b6a0b6579c249fca9026ce7c333fc142ba42411fa243cdc", size = 2009000 },
+    { url = "https://files.pythonhosted.org/packages/a1/02/6224312aacb3c8ecbaa959897af57181fb6cf3a3d7917fd44d0f2917e6f2/pydantic_core-2.33.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3c6db6e52c6d70aa0d00d45cdb9b40f0433b96380071ea80b09277dba021ddf7", size = 1847996 },
+    { url = "https://files.pythonhosted.org/packages/d6/46/6dcdf084a523dbe0a0be59d054734b86a981726f221f4562aed313dbcb49/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e61206137cbc65e6d5256e1166f88331d3b6238e082d9f74613b9b765fb9025", size = 1880957 },
+    { url = "https://files.pythonhosted.org/packages/ec/6b/1ec2c03837ac00886ba8160ce041ce4e325b41d06a034adbef11339ae422/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eb8c529b2819c37140eb51b914153063d27ed88e3bdc31b71198a198e921e011", size = 1964199 },
+    { url = "https://files.pythonhosted.org/packages/2d/1d/6bf34d6adb9debd9136bd197ca72642203ce9aaaa85cfcbfcf20f9696e83/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c52b02ad8b4e2cf14ca7b3d918f3eb0ee91e63b3167c32591e57c4317e134f8f", size = 2120296 },
+    { url = "https://files.pythonhosted.org/packages/e0/94/2bd0aaf5a591e974b32a9f7123f16637776c304471a0ab33cf263cf5591a/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:96081f1605125ba0855dfda83f6f3df5ec90c61195421ba72223de35ccfb2f88", size = 2676109 },
+    { url = "https://files.pythonhosted.org/packages/f9/41/4b043778cf9c4285d59742281a769eac371b9e47e35f98ad321349cc5d61/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f57a69461af2a5fa6e6bbd7a5f60d3b7e6cebb687f55106933188e79ad155c1", size = 2002028 },
+    { url = "https://files.pythonhosted.org/packages/cb/d5/7bb781bf2748ce3d03af04d5c969fa1308880e1dca35a9bd94e1a96a922e/pydantic_core-2.33.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:572c7e6c8bb4774d2ac88929e3d1f12bc45714ae5ee6d9a788a9fb35e60bb04b", size = 2100044 },
+    { url = "https://files.pythonhosted.org/packages/fe/36/def5e53e1eb0ad896785702a5bbfd25eed546cdcf4087ad285021a90ed53/pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:db4b41f9bd95fbe5acd76d89920336ba96f03e149097365afe1cb092fceb89a1", size = 2058881 },
+    { url = "https://files.pythonhosted.org/packages/01/6c/57f8d70b2ee57fc3dc8b9610315949837fa8c11d86927b9bb044f8705419/pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:fa854f5cf7e33842a892e5c73f45327760bc7bc516339fda888c75ae60edaeb6", size = 2227034 },
+    { url = "https://files.pythonhosted.org/packages/27/b9/9c17f0396a82b3d5cbea4c24d742083422639e7bb1d5bf600e12cb176a13/pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:5f483cfb75ff703095c59e365360cb73e00185e01aaea067cd19acffd2ab20ea", size = 2234187 },
+    { url = "https://files.pythonhosted.org/packages/b0/6a/adf5734ffd52bf86d865093ad70b2ce543415e0e356f6cacabbc0d9ad910/pydantic_core-2.33.2-cp312-cp312-win32.whl", hash = "sha256:9cb1da0f5a471435a7bc7e439b8a728e8b61e59784b2af70d7c169f8dd8ae290", size = 1892628 },
+    { url = "https://files.pythonhosted.org/packages/43/e4/5479fecb3606c1368d496a825d8411e126133c41224c1e7238be58b87d7e/pydantic_core-2.33.2-cp312-cp312-win_amd64.whl", hash = "sha256:f941635f2a3d96b2973e867144fde513665c87f13fe0e193c158ac51bfaaa7b2", size = 1955866 },
+    { url = "https://files.pythonhosted.org/packages/0d/24/8b11e8b3e2be9dd82df4b11408a67c61bb4dc4f8e11b5b0fc888b38118b5/pydantic_core-2.33.2-cp312-cp312-win_arm64.whl", hash = "sha256:cca3868ddfaccfbc4bfb1d608e2ccaaebe0ae628e1416aeb9c4d88c001bb45ab", size = 1888894 },
+    { url = "https://files.pythonhosted.org/packages/46/8c/99040727b41f56616573a28771b1bfa08a3d3fe74d3d513f01251f79f172/pydantic_core-2.33.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1082dd3e2d7109ad8b7da48e1d4710c8d06c253cbc4a27c1cff4fbcaa97a9e3f", size = 2015688 },
+    { url = "https://files.pythonhosted.org/packages/3a/cc/5999d1eb705a6cefc31f0b4a90e9f7fc400539b1a1030529700cc1b51838/pydantic_core-2.33.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f517ca031dfc037a9c07e748cefd8d96235088b83b4f4ba8939105d20fa1dcd6", size = 1844808 },
+    { url = "https://files.pythonhosted.org/packages/6f/5e/a0a7b8885c98889a18b6e376f344da1ef323d270b44edf8174d6bce4d622/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a9f2c9dd19656823cb8250b0724ee9c60a82f3cdf68a080979d13092a3b0fef", size = 1885580 },
+    { url = "https://files.pythonhosted.org/packages/3b/2a/953581f343c7d11a304581156618c3f592435523dd9d79865903272c256a/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2b0a451c263b01acebe51895bfb0e1cc842a5c666efe06cdf13846c7418caa9a", size = 1973859 },
+    { url = "https://files.pythonhosted.org/packages/e6/55/f1a813904771c03a3f97f676c62cca0c0a4138654107c1b61f19c644868b/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1ea40a64d23faa25e62a70ad163571c0b342b8bf66d5fa612ac0dec4f069d916", size = 2120810 },
+    { url = "https://files.pythonhosted.org/packages/aa/c3/053389835a996e18853ba107a63caae0b9deb4a276c6b472931ea9ae6e48/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0fb2d542b4d66f9470e8065c5469ec676978d625a8b7a363f07d9a501a9cb36a", size = 2676498 },
+    { url = "https://files.pythonhosted.org/packages/eb/3c/f4abd740877a35abade05e437245b192f9d0ffb48bbbbd708df33d3cda37/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9fdac5d6ffa1b5a83bca06ffe7583f5576555e6c8b3a91fbd25ea7780f825f7d", size = 2000611 },
+    { url = "https://files.pythonhosted.org/packages/59/a7/63ef2fed1837d1121a894d0ce88439fe3e3b3e48c7543b2a4479eb99c2bd/pydantic_core-2.33.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:04a1a413977ab517154eebb2d326da71638271477d6ad87a769102f7c2488c56", size = 2107924 },
+    { url = "https://files.pythonhosted.org/packages/04/8f/2551964ef045669801675f1cfc3b0d74147f4901c3ffa42be2ddb1f0efc4/pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c8e7af2f4e0194c22b5b37205bfb293d166a7344a5b0d0eaccebc376546d77d5", size = 2063196 },
+    { url = "https://files.pythonhosted.org/packages/26/bd/d9602777e77fc6dbb0c7db9ad356e9a985825547dce5ad1d30ee04903918/pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:5c92edd15cd58b3c2d34873597a1e20f13094f59cf88068adb18947df5455b4e", size = 2236389 },
+    { url = "https://files.pythonhosted.org/packages/42/db/0e950daa7e2230423ab342ae918a794964b053bec24ba8af013fc7c94846/pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:65132b7b4a1c0beded5e057324b7e16e10910c106d43675d9bd87d4f38dde162", size = 2239223 },
+    { url = "https://files.pythonhosted.org/packages/58/4d/4f937099c545a8a17eb52cb67fe0447fd9a373b348ccfa9a87f141eeb00f/pydantic_core-2.33.2-cp313-cp313-win32.whl", hash = "sha256:52fb90784e0a242bb96ec53f42196a17278855b0f31ac7c3cc6f5c1ec4811849", size = 1900473 },
+    { url = "https://files.pythonhosted.org/packages/a0/75/4a0a9bac998d78d889def5e4ef2b065acba8cae8c93696906c3a91f310ca/pydantic_core-2.33.2-cp313-cp313-win_amd64.whl", hash = "sha256:c083a3bdd5a93dfe480f1125926afcdbf2917ae714bdb80b36d34318b2bec5d9", size = 1955269 },
+    { url = "https://files.pythonhosted.org/packages/f9/86/1beda0576969592f1497b4ce8e7bc8cbdf614c352426271b1b10d5f0aa64/pydantic_core-2.33.2-cp313-cp313-win_arm64.whl", hash = "sha256:e80b087132752f6b3d714f041ccf74403799d3b23a72722ea2e6ba2e892555b9", size = 1893921 },
+    { url = "https://files.pythonhosted.org/packages/a4/7d/e09391c2eebeab681df2b74bfe6c43422fffede8dc74187b2b0bf6fd7571/pydantic_core-2.33.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:61c18fba8e5e9db3ab908620af374db0ac1baa69f0f32df4f61ae23f15e586ac", size = 1806162 },
+    { url = "https://files.pythonhosted.org/packages/f1/3d/847b6b1fed9f8ed3bb95a9ad04fbd0b212e832d4f0f50ff4d9ee5a9f15cf/pydantic_core-2.33.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95237e53bb015f67b63c91af7518a62a8660376a6a0db19b89acc77a4d6199f5", size = 1981560 },
+    { url = "https://files.pythonhosted.org/packages/6f/9a/e73262f6c6656262b5fdd723ad90f518f579b7bc8622e43a942eec53c938/pydantic_core-2.33.2-cp313-cp313t-win_amd64.whl", hash = "sha256:c2fc0a768ef76c15ab9238afa6da7f69895bb5d1ee83aeea2e3509af4472d0b9", size = 1935777 },
+    { url = "https://files.pythonhosted.org/packages/7b/27/d4ae6487d73948d6f20dddcd94be4ea43e74349b56eba82e9bdee2d7494c/pydantic_core-2.33.2-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:dd14041875d09cc0f9308e37a6f8b65f5585cf2598a53aa0123df8b129d481f8", size = 2025200 },
+    { url = "https://files.pythonhosted.org/packages/f1/b8/b3cb95375f05d33801024079b9392a5ab45267a63400bf1866e7ce0f0de4/pydantic_core-2.33.2-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d87c561733f66531dced0da6e864f44ebf89a8fba55f31407b00c2f7f9449593", size = 1859123 },
+    { url = "https://files.pythonhosted.org/packages/05/bc/0d0b5adeda59a261cd30a1235a445bf55c7e46ae44aea28f7bd6ed46e091/pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2f82865531efd18d6e07a04a17331af02cb7a651583c418df8266f17a63c6612", size = 1892852 },
+    { url = "https://files.pythonhosted.org/packages/3e/11/d37bdebbda2e449cb3f519f6ce950927b56d62f0b84fd9cb9e372a26a3d5/pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bfb5112df54209d820d7bf9317c7a6c9025ea52e49f46b6a2060104bba37de7", size = 2067484 },
+    { url = "https://files.pythonhosted.org/packages/8c/55/1f95f0a05ce72ecb02a8a8a1c3be0579bbc29b1d5ab68f1378b7bebc5057/pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:64632ff9d614e5eecfb495796ad51b0ed98c453e447a76bcbeeb69615079fc7e", size = 2108896 },
+    { url = "https://files.pythonhosted.org/packages/53/89/2b2de6c81fa131f423246a9109d7b2a375e83968ad0800d6e57d0574629b/pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:f889f7a40498cc077332c7ab6b4608d296d852182211787d4f3ee377aaae66e8", size = 2069475 },
+    { url = "https://files.pythonhosted.org/packages/b8/e9/1f7efbe20d0b2b10f6718944b5d8ece9152390904f29a78e68d4e7961159/pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:de4b83bb311557e439b9e186f733f6c645b9417c84e2eb8203f3f820a4b988bf", size = 2239013 },
+    { url = "https://files.pythonhosted.org/packages/3c/b2/5309c905a93811524a49b4e031e9851a6b00ff0fb668794472ea7746b448/pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:82f68293f055f51b51ea42fafc74b6aad03e70e191799430b90c13d643059ebb", size = 2238715 },
+    { url = "https://files.pythonhosted.org/packages/32/56/8a7ca5d2cd2cda1d245d34b1c9a942920a718082ae8e54e5f3e5a58b7add/pydantic_core-2.33.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:329467cecfb529c925cf2bbd4d60d2c509bc2fb52a20c1045bf09bb70971a9c1", size = 2066757 },
+]
+
+[[package]]
+name = "pyg-lib"
+version = "0.4.0+pt24cu124"
+source = { registry = "https://data.pyg.org/whl/torch-2.4.0+cu124.html" }
+wheels = [
+    { url = "https://data.pyg.org/whl/torch-2.4.0%2Bcu124/pyg_lib-0.4.0%2Bpt24cu124-cp311-cp311-linux_x86_64.whl" },
+    { url = "https://data.pyg.org/whl/torch-2.4.0%2Bcu124/pyg_lib-0.4.0%2Bpt24cu124-cp311-cp311-win_amd64.whl" },
+    { url = "https://data.pyg.org/whl/torch-2.4.0%2Bcu124/pyg_lib-0.4.0%2Bpt24cu124-cp312-cp312-linux_x86_64.whl" },
+    { url = "https://data.pyg.org/whl/torch-2.4.0%2Bcu124/pyg_lib-0.4.0%2Bpt24cu124-cp312-cp312-win_amd64.whl" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2351,7 +3284,9 @@ dependencies = [
     { name = "matplotlib" },
     { name = "monty" },
     { name = "networkx" },
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-fairchem' or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "numpy", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-mace' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-orb' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace')" },
     { name = "orjson" },
     { name = "palettable" },
     { name = "pandas" },
@@ -2360,7 +3295,8 @@ dependencies = [
     { name = "ruamel-yaml" },
     { name = "scipy" },
     { name = "spglib" },
-    { name = "sympy" },
+    { name = "sympy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-mace' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "sympy", version = "1.14.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-fairchem' or extra != 'extra-21-lematerial-forgebench-mace' or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
     { name = "tabulate" },
     { name = "tqdm" },
     { name = "uncertainties" },
@@ -2396,11 +3332,24 @@ wheels = [
 ]
 
 [[package]]
+name = "pyre-extensions"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+    { name = "typing-inspect" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/53/5bc2532536e921c48366ad1047c1344ccef6afa5e84053f0f6e20a453767/pyre_extensions-0.0.32.tar.gz", hash = "sha256:5396715f14ea56c4d5fd0a88c57ca7e44faa468f905909edd7de4ad90ed85e55", size = 10852 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/7a/9812cb8be9828ab688203c5ac5f743c60652887f0c00995a6f6f19f912bd/pyre_extensions-0.0.32-py3-none-any.whl", hash = "sha256:a63ba6883ab02f4b1a9f372ed4eb4a2f4c6f3d74879aa2725186fdfcfe3e5c68", size = 12766 },
+]
+
+[[package]]
 name = "pytest"
 version = "8.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb') or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
@@ -2612,7 +3561,9 @@ version = "1.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "joblib" },
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-fairchem' or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "numpy", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-mace' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-orb' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace')" },
     { name = "scipy" },
     { name = "threadpoolctl" },
 ]
@@ -2644,7 +3595,9 @@ name = "scipy"
 version = "1.15.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-fairchem' or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "numpy", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-mace' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-orb' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214 }
 wheels = [
@@ -2684,6 +3637,75 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/8e/038ccfe29d272b30086b25a4960f757f97122cb2ec42e62b460d02fe98e9/scipy-1.15.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:40e54d5c7e7ebf1aa596c374c49fa3135f04648a0caabcb66c52884b943f02b4", size = 36393132 },
     { url = "https://files.pythonhosted.org/packages/10/7e/5c12285452970be5bdbe8352c619250b97ebf7917d7a9a9e96b8a8140f17/scipy-1.15.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:5e721fed53187e71d0ccf382b6bf977644c533e506c4d33c3fb24de89f5c3ed5", size = 38979503 },
     { url = "https://files.pythonhosted.org/packages/81/06/0a5e5349474e1cbc5757975b21bd4fad0e72ebf138c5592f191646154e06/scipy-1.15.3-cp313-cp313t-win_amd64.whl", hash = "sha256:76ad1fb5f8752eabf0fa02e4cc0336b4e8f021e2d5f061ed37d6d264db35e3ca", size = 40308097 },
+]
+
+[[package]]
+name = "sentry-sdk"
+version = "2.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/4c/af31e0201b48469786ddeb1bf6fd3dfa3a291cc613a0fe6a60163a7535f9/sentry_sdk-2.30.0.tar.gz", hash = "sha256:436369b02afef7430efb10300a344fb61a11fe6db41c2b11f41ee037d2dd7f45", size = 326767 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/99/31ac6faaae33ea698086692638f58d14f121162a8db0039e68e94135e7f1/sentry_sdk-2.30.0-py2.py3-none-any.whl", hash = "sha256:59391db1550662f746ea09b483806a631c3ae38d6340804a1a4c0605044f6877", size = 343149 },
+]
+
+[[package]]
+name = "setproctitle"
+version = "1.3.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/af/56efe21c53ac81ac87e000b15e60b3d8104224b4313b6eacac3597bd183d/setproctitle-1.3.6.tar.gz", hash = "sha256:c9f32b96c700bb384f33f7cf07954bb609d35dd82752cef57fb2ee0968409169", size = 26889 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/3b/8288d0cd969a63500dd62fc2c99ce6980f9909ccef0770ab1f86c361e0bf/setproctitle-1.3.6-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a1d856b0f4e4a33e31cdab5f50d0a14998f3a2d726a3fd5cb7c4d45a57b28d1b", size = 17412 },
+    { url = "https://files.pythonhosted.org/packages/39/37/43a5a3e25ca1048dbbf4db0d88d346226f5f1acd131bb8e660f4bfe2799f/setproctitle-1.3.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:50706b9c0eda55f7de18695bfeead5f28b58aa42fd5219b3b1692d554ecbc9ec", size = 11963 },
+    { url = "https://files.pythonhosted.org/packages/5b/47/f103c40e133154783c91a10ab08ac9fc410ed835aa85bcf7107cb882f505/setproctitle-1.3.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:af188f3305f0a65c3217c30c6d4c06891e79144076a91e8b454f14256acc7279", size = 31718 },
+    { url = "https://files.pythonhosted.org/packages/1f/13/7325dd1c008dd6c0ebd370ddb7505977054a87e406f142318e395031a792/setproctitle-1.3.6-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cce0ed8b3f64c71c140f0ec244e5fdf8ecf78ddf8d2e591d4a8b6aa1c1214235", size = 33027 },
+    { url = "https://files.pythonhosted.org/packages/0c/0a/6075bfea05a71379d77af98a9ac61163e8b6e5ef1ae58cd2b05871b2079c/setproctitle-1.3.6-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:70100e2087fe05359f249a0b5f393127b3a1819bf34dec3a3e0d4941138650c9", size = 30223 },
+    { url = "https://files.pythonhosted.org/packages/cc/41/fbf57ec52f4f0776193bd94334a841f0bc9d17e745f89c7790f336420c65/setproctitle-1.3.6-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1065ed36bd03a3fd4186d6c6de5f19846650b015789f72e2dea2d77be99bdca1", size = 31204 },
+    { url = "https://files.pythonhosted.org/packages/97/b5/f799fb7a00de29fb0ac1dfd015528dea425b9e31a8f1068a0b3df52d317f/setproctitle-1.3.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4adf6a0013fe4e0844e3ba7583ec203ca518b9394c6cc0d3354df2bf31d1c034", size = 31181 },
+    { url = "https://files.pythonhosted.org/packages/b5/b7/81f101b612014ec61723436022c31146178813d6ca6b947f7b9c84e9daf4/setproctitle-1.3.6-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:eb7452849f6615871eabed6560ffedfe56bc8af31a823b6be4ce1e6ff0ab72c5", size = 30101 },
+    { url = "https://files.pythonhosted.org/packages/67/23/681232eed7640eab96719daa8647cc99b639e3daff5c287bd270ef179a73/setproctitle-1.3.6-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:a094b7ce455ca341b59a0f6ce6be2e11411ba6e2860b9aa3dbb37468f23338f4", size = 32438 },
+    { url = "https://files.pythonhosted.org/packages/19/f8/4d075a7bdc3609ac71535b849775812455e4c40aedfbf0778a6f123b1774/setproctitle-1.3.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ad1c2c2baaba62823a7f348f469a967ece0062140ca39e7a48e4bbb1f20d54c4", size = 30625 },
+    { url = "https://files.pythonhosted.org/packages/5f/73/a2a8259ebee166aee1ca53eead75de0e190b3ddca4f716e5c7470ebb7ef6/setproctitle-1.3.6-cp311-cp311-win32.whl", hash = "sha256:8050c01331135f77ec99d99307bfbc6519ea24d2f92964b06f3222a804a3ff1f", size = 11488 },
+    { url = "https://files.pythonhosted.org/packages/c9/15/52cf5e1ff0727d53704cfdde2858eaf237ce523b0b04db65faa84ff83e13/setproctitle-1.3.6-cp311-cp311-win_amd64.whl", hash = "sha256:9b73cf0fe28009a04a35bb2522e4c5b5176cc148919431dcb73fdbdfaab15781", size = 12201 },
+    { url = "https://files.pythonhosted.org/packages/8f/fb/99456fd94d4207c5f6c40746a048a33a52b4239cd7d9c8d4889e2210ec82/setproctitle-1.3.6-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:af44bb7a1af163806bbb679eb8432fa7b4fb6d83a5d403b541b675dcd3798638", size = 17399 },
+    { url = "https://files.pythonhosted.org/packages/d5/48/9699191fe6062827683c43bfa9caac33a2c89f8781dd8c7253fa3dba85fd/setproctitle-1.3.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3cca16fd055316a48f0debfcbfb6af7cea715429fc31515ab3fcac05abd527d8", size = 11966 },
+    { url = "https://files.pythonhosted.org/packages/33/03/b085d192b9ecb9c7ce6ad6ef30ecf4110b7f39430b58a56245569827fcf4/setproctitle-1.3.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ea002088d5554fd75e619742cefc78b84a212ba21632e59931b3501f0cfc8f67", size = 32017 },
+    { url = "https://files.pythonhosted.org/packages/ae/68/c53162e645816f97212002111420d1b2f75bf6d02632e37e961dc2cd6d8b/setproctitle-1.3.6-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bb465dd5825356c1191a038a86ee1b8166e3562d6e8add95eec04ab484cfb8a2", size = 33419 },
+    { url = "https://files.pythonhosted.org/packages/ac/0d/119a45d15a816a6cf5ccc61b19729f82620095b27a47e0a6838216a95fae/setproctitle-1.3.6-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d2c8e20487b3b73c1fa72c56f5c89430617296cd380373e7af3a538a82d4cd6d", size = 30711 },
+    { url = "https://files.pythonhosted.org/packages/e3/fb/5e9b5068df9e9f31a722a775a5e8322a29a638eaaa3eac5ea7f0b35e6314/setproctitle-1.3.6-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0d6252098e98129a1decb59b46920d4eca17b0395f3d71b0d327d086fefe77d", size = 31742 },
+    { url = "https://files.pythonhosted.org/packages/35/88/54de1e73e8fce87d587889c7eedb48fc4ee2bbe4e4ca6331690d03024f86/setproctitle-1.3.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:cf355fbf0d4275d86f9f57be705d8e5eaa7f8ddb12b24ced2ea6cbd68fdb14dc", size = 31925 },
+    { url = "https://files.pythonhosted.org/packages/f3/01/65948d7badd66e63e3db247b923143da142790fa293830fdecf832712c2d/setproctitle-1.3.6-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e288f8a162d663916060beb5e8165a8551312b08efee9cf68302687471a6545d", size = 30981 },
+    { url = "https://files.pythonhosted.org/packages/22/20/c495e61786f1d38d5dc340b9d9077fee9be3dfc7e89f515afe12e1526dbc/setproctitle-1.3.6-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:b2e54f4a2dc6edf0f5ea5b1d0a608d2af3dcb5aa8c8eeab9c8841b23e1b054fe", size = 33209 },
+    { url = "https://files.pythonhosted.org/packages/98/3f/a457b8550fbd34d5b482fe20b8376b529e76bf1fbf9a474a6d9a641ab4ad/setproctitle-1.3.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b6f4abde9a2946f57e8daaf1160b2351bcf64274ef539e6675c1d945dbd75e2a", size = 31587 },
+    { url = "https://files.pythonhosted.org/packages/44/fe/743517340e5a635e3f1c4310baea20c16c66202f96a6f4cead222ffd6d84/setproctitle-1.3.6-cp312-cp312-win32.whl", hash = "sha256:db608db98ccc21248370d30044a60843b3f0f3d34781ceeea67067c508cd5a28", size = 11487 },
+    { url = "https://files.pythonhosted.org/packages/60/9a/d88f1c1f0f4efff1bd29d9233583ee341114dda7d9613941453984849674/setproctitle-1.3.6-cp312-cp312-win_amd64.whl", hash = "sha256:082413db8a96b1f021088e8ec23f0a61fec352e649aba20881895815388b66d3", size = 12208 },
+    { url = "https://files.pythonhosted.org/packages/89/76/f1a2fdbf9b9602945a7489ba5c52e9863de37381ef1a85a2b9ed0ff8bc79/setproctitle-1.3.6-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e2a9e62647dc040a76d55563580bf3bb8fe1f5b6ead08447c2ed0d7786e5e794", size = 17392 },
+    { url = "https://files.pythonhosted.org/packages/5c/5b/4e0db8b10b4543afcb3dbc0827793d46e43ec1de6b377e313af3703d08e0/setproctitle-1.3.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:751ba352ed922e0af60458e961167fa7b732ac31c0ddd1476a2dfd30ab5958c5", size = 11951 },
+    { url = "https://files.pythonhosted.org/packages/dc/fe/d5d00aaa700fe1f6160b6e95c225b29c01f4d9292176d48fd968815163ea/setproctitle-1.3.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7890e291bf4708e3b61db9069ea39b3ab0651e42923a5e1f4d78a7b9e4b18301", size = 32087 },
+    { url = "https://files.pythonhosted.org/packages/9f/b3/894b827b93ef813c082479bebf88185860f01ac243df737823dd705e7fff/setproctitle-1.3.6-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b2b17855ed7f994f3f259cf2dfbfad78814538536fa1a91b50253d84d87fd88d", size = 33502 },
+    { url = "https://files.pythonhosted.org/packages/b2/cd/5330734cca1a4cfcb721432c22cb7899ff15a4101ba868b2ef452ffafea1/setproctitle-1.3.6-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2e51ec673513465663008ce402171192a053564865c2fc6dc840620871a9bd7c", size = 30713 },
+    { url = "https://files.pythonhosted.org/packages/fa/d3/c2590c5daa2e9a008d3f2b16c0f4a351826193be55f147cb32af49c6d814/setproctitle-1.3.6-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:63cc10352dc6cf35a33951656aa660d99f25f574eb78132ce41a85001a638aa7", size = 31792 },
+    { url = "https://files.pythonhosted.org/packages/e6/b1/c553ed5af8cfcecd5ae7737e63af58a17a03d26f3d61868c7eb20bf7e3cf/setproctitle-1.3.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0dba8faee2e4a96e934797c9f0f2d093f8239bf210406a99060b3eabe549628e", size = 31927 },
+    { url = "https://files.pythonhosted.org/packages/70/78/2d5385206540127a3dca0ff83225b1ac66873f5cc89d4a6d3806c92f5ae2/setproctitle-1.3.6-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e3e44d08b61de0dd6f205528498f834a51a5c06689f8fb182fe26f3a3ce7dca9", size = 30981 },
+    { url = "https://files.pythonhosted.org/packages/31/62/e3e4a4e006d0e549748e53cded4ff3b667be0602860fc61b7de8b412b667/setproctitle-1.3.6-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:de004939fc3fd0c1200d26ea9264350bfe501ffbf46c8cf5dc7f345f2d87a7f1", size = 33244 },
+    { url = "https://files.pythonhosted.org/packages/aa/05/4b223fd4ef94e105dc7aff27fa502fb7200cf52be2bb0c064bd2406b5611/setproctitle-1.3.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3f8194b4d631b003a1176a75d1acd545e04b1f54b821638e098a93e6e62830ef", size = 31630 },
+    { url = "https://files.pythonhosted.org/packages/1b/ba/5f68eb969f7336f54b54a599fd3ffbd7662f9733b080bc8598705971b3dd/setproctitle-1.3.6-cp313-cp313-win32.whl", hash = "sha256:d714e002dd3638170fe7376dc1b686dbac9cb712cde3f7224440af722cc9866a", size = 11480 },
+    { url = "https://files.pythonhosted.org/packages/ba/f5/7f47f0ca35c9c357f16187cee9229f3eda0237bc6fdd3061441336f361c0/setproctitle-1.3.6-cp313-cp313-win_amd64.whl", hash = "sha256:b70c07409d465f3a8b34d52f863871fb8a00755370791d2bd1d4f82b3cdaf3d5", size = 12198 },
+    { url = "https://files.pythonhosted.org/packages/39/ad/c3941b8fc6b32a976c9e2d9615a90ae793b69cd010ca8c3575dbc822104f/setproctitle-1.3.6-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:23a57d3b8f1549515c2dbe4a2880ebc1f27780dc126c5e064167563e015817f5", size = 17401 },
+    { url = "https://files.pythonhosted.org/packages/04/38/a184f857b988d3a9c401e470a4e38182a5c99ee77bf90432d7665e9d35a3/setproctitle-1.3.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:81c443310831e29fabbd07b75ebbfa29d0740b56f5907c6af218482d51260431", size = 11959 },
+    { url = "https://files.pythonhosted.org/packages/b7/b9/4878ef9d8483adfd1edf6bf95151362aaec0d05aac306a97ff0383f491b5/setproctitle-1.3.6-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d88c63bd395c787b0aa81d8bbc22c1809f311032ce3e823a6517b711129818e4", size = 33463 },
+    { url = "https://files.pythonhosted.org/packages/cc/60/3ef49d1931aff2a36a7324a49cca10d77ef03e0278452fd468c33a52d7e3/setproctitle-1.3.6-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d73f14b86d0e2858ece6bf5807c9889670e392c001d414b4293d0d9b291942c3", size = 34959 },
+    { url = "https://files.pythonhosted.org/packages/81/c6/dee0a973acecefb0db6c9c2e0ea7f18b7e4db773a72e534741ebdee8bbb8/setproctitle-1.3.6-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3393859eb8f19f5804049a685bf286cb08d447e28ba5c6d8543c7bf5500d5970", size = 32055 },
+    { url = "https://files.pythonhosted.org/packages/ea/a5/5dd5c4192cf18d16349a32a07f728a9a48a2a05178e16966cabd6645903e/setproctitle-1.3.6-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:785cd210c0311d9be28a70e281a914486d62bfd44ac926fcd70cf0b4d65dff1c", size = 32986 },
+    { url = "https://files.pythonhosted.org/packages/df/a6/1508d37eb8008670d33f13fcdb91cbd8ef54697276469abbfdd3d4428c59/setproctitle-1.3.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c051f46ed1e13ba8214b334cbf21902102807582fbfaf0fef341b9e52f0fafbf", size = 32736 },
+    { url = "https://files.pythonhosted.org/packages/1a/73/c84ec8880d543766a12fcd6b65dbd013770974a40577889f357409b0441e/setproctitle-1.3.6-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:49498ebf68ca3e75321ffe634fcea5cc720502bfaa79bd6b03ded92ce0dc3c24", size = 31945 },
+    { url = "https://files.pythonhosted.org/packages/95/0a/126b9ff7a406a69a62825fe5bd6d1ba8671919a7018c4f9e2c63f49bfcb6/setproctitle-1.3.6-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:4431629c178193f23c538cb1de3da285a99ccc86b20ee91d81eb5f1a80e0d2ba", size = 34333 },
+    { url = "https://files.pythonhosted.org/packages/9a/fd/5474b04f1c013ff460129d2bc774557dd6e186da4667865efef9a83bf378/setproctitle-1.3.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:d136fbf8ad4321716e44d6d6b3d8dffb4872626010884e07a1db54b7450836cf", size = 32508 },
+    { url = "https://files.pythonhosted.org/packages/32/21/2503e38520cb076a7ecaef6a35d6a6fa89cf02af3541c84c811fd7500d20/setproctitle-1.3.6-cp313-cp313t-win32.whl", hash = "sha256:d483cc23cc56ab32911ea0baa0d2d9ea7aa065987f47de847a0a93a58bf57905", size = 11482 },
+    { url = "https://files.pythonhosted.org/packages/65/23/7833d75a27fba25ddc5cd3b54cd03c4bf8e18b8e2dbec622eb6326278ce8/setproctitle-1.3.6-cp313-cp313t-win_amd64.whl", hash = "sha256:74973aebea3543ad033b9103db30579ec2b950a466e09f9c2180089e8346e0ec", size = 12209 },
 ]
 
 [[package]]
@@ -2748,7 +3770,9 @@ name = "spglib"
 version = "2.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-fairchem' or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "numpy", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-mace' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-orb' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace')" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bf/34/1fe99124be59579ebd24316522e1da780979c856977b142c0dcd878b0a2d/spglib-2.6.0.tar.gz", hash = "sha256:d66eda2ba00a1e14fd96ec9c3b4dbf8ab0fb3f124643e35785c71ee455b408eb", size = 2360880 }
@@ -2777,7 +3801,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "alabaster" },
     { name = "babel" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb') or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
     { name = "docutils" },
     { name = "imagesize" },
     { name = "jinja2" },
@@ -2880,7 +3904,7 @@ version = "5.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
-    { name = "sphinx", marker = "python_full_version < '3.13'" },
+    { name = "sphinx", marker = "python_full_version < '3.13' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb') or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/45/58/6f3e05f77c881e1356d73fc1d99561efe1795671bd56e7fb47c63a32cc1f/sphinxawesome_theme-5.3.2.tar.gz", hash = "sha256:0629d38b80aefc279b1186c53a7a6faf21e721b5b2ecda14f488ca1074e2631f", size = 364039 }
 wheels = [
@@ -2971,11 +3995,60 @@ wheels = [
 ]
 
 [[package]]
+name = "submitit"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/2c/a824e3e03cbc4a48892014c5826fee7350994f4b6ae45c120e7713b2b7a1/submitit-1.5.3.tar.gz", hash = "sha256:d1cbc5d8859b519b1e47adc4aaa6001dcefe8a835f3032b151cb3de7d2841068", size = 81019 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/80/90e0a0f4008f6572de58b042b1db9daced15d348a3586dda5efc9faba65e/submitit-1.5.3-py3-none-any.whl", hash = "sha256:ccc35100da12fe916541489deccccb6b9fa93dae8c01ade53e7f643552dc1795", size = 75463 },
+]
+
+[[package]]
+name = "sympy"
+version = "1.13.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "mpmath", marker = "extra == 'extra-21-lematerial-forgebench-mace' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/99/5a5b6f19ff9f083671ddf7b9632028436167cd3d33e11015754e41b249a4/sympy-1.13.1.tar.gz", hash = "sha256:9cebf7e04ff162015ce31c9c6c9144daa34a93bd082f54fd8f12deca4f47515f", size = 7533040 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/fe/81695a1aa331a842b582453b605175f419fe8540355886031328089d840a/sympy-1.13.1-py3-none-any.whl", hash = "sha256:db36cdc64bf61b9b24578b6f7bab1ecdd2452cf008f34faa33776680c26d66f8", size = 6189177 },
+]
+
+[[package]]
 name = "sympy"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.13' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform == 'win32' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform == 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform == 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+]
 dependencies = [
-    { name = "mpmath" },
+    { name = "mpmath", marker = "extra == 'extra-21-lematerial-forgebench-fairchem' or extra != 'extra-21-lematerial-forgebench-mace' or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921 }
 wheels = [
@@ -2992,6 +4065,36 @@ wheels = [
 ]
 
 [[package]]
+name = "tensorboard"
+version = "2.19.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "grpcio" },
+    { name = "markdown" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "setuptools" },
+    { name = "six" },
+    { name = "tensorboard-data-server" },
+    { name = "werkzeug" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/12/4f70e8e2ba0dbe72ea978429d8530b0333f0ed2140cc571a48802878ef99/tensorboard-2.19.0-py3-none-any.whl", hash = "sha256:5e71b98663a641a7ce8a6e70b0be8e1a4c0c45d48760b076383ac4755c35b9a0", size = 5503412 },
+]
+
+[[package]]
+name = "tensorboard-data-server"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/13/e503968fefabd4c6b2650af21e110aa8466fe21432cd7c43a84577a89438/tensorboard_data_server-0.7.2-py3-none-any.whl", hash = "sha256:7e0610d205889588983836ec05dc098e80f97b7e7bbff7e994ebb78f578d0ddb", size = 2356 },
+    { url = "https://files.pythonhosted.org/packages/b7/85/dabeaf902892922777492e1d253bb7e1264cadce3cea932f7ff599e53fea/tensorboard_data_server-0.7.2-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:9fe5d24221b29625dbc7328b0436ca7fc1c23de4acf4d272f1180856e32f9f60", size = 4823598 },
+    { url = "https://files.pythonhosted.org/packages/73/c6/825dab04195756cf8ff2e12698f22513b3db2f64925bdd41671bfb33aaa5/tensorboard_data_server-0.7.2-py3-none-manylinux_2_31_x86_64.whl", hash = "sha256:ef687163c24185ae9754ed5650eb5bc4d84ff257aabdc33f0cc6f74d8ba54530", size = 6590363 },
+]
+
+[[package]]
 name = "threadpoolctl"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3002,30 +4105,133 @@ wheels = [
 
 [[package]]
 name = "torch"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and sys_platform == 'linux'",
+    "python_full_version >= '3.12' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'linux'",
+    "python_full_version < '3.12' and sys_platform != 'linux' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "filelock", marker = "extra == 'extra-21-lematerial-forgebench-fairchem' or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "fsspec", marker = "extra == 'extra-21-lematerial-forgebench-fairchem' or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "jinja2", marker = "extra == 'extra-21-lematerial-forgebench-fairchem' or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "networkx", marker = "extra == 'extra-21-lematerial-forgebench-fairchem' or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "nvidia-cublas-cu12", version = "12.1.3.1", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (extra != 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "nvidia-cuda-cupti-cu12", version = "12.1.105", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (extra != 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "nvidia-cuda-nvrtc-cu12", version = "12.1.105", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (extra != 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "nvidia-cuda-runtime-cu12", version = "12.1.105", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (extra != 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "nvidia-cudnn-cu12", version = "9.1.0.70", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (extra != 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "nvidia-cufft-cu12", version = "11.0.2.54", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (extra != 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "nvidia-curand-cu12", version = "10.3.2.106", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (extra != 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "nvidia-cusolver-cu12", version = "11.4.5.107", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (extra != 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "nvidia-cusparse-cu12", version = "12.1.0.106", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (extra != 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "nvidia-nccl-cu12", version = "2.20.5", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (extra != 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "nvidia-nvtx-cu12", version = "12.1.105", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (extra != 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "sympy", version = "1.14.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-fairchem' or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "triton", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem') or (python_full_version >= '3.13' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (python_full_version >= '3.13' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (extra != 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "typing-extensions", marker = "extra == 'extra-21-lematerial-forgebench-fairchem' or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/83/9b7681e41e59adb6c2b042f7e8eb716515665a6eed3dda4215c6b3385b90/torch-2.4.0-cp311-cp311-manylinux1_x86_64.whl", hash = "sha256:e743adadd8c8152bb8373543964551a7cb7cc20ba898dc8f9c0cdbe47c283de0", size = 797262052 },
+    { url = "https://files.pythonhosted.org/packages/84/fa/2b510a02809ddd70aed821bc2328c4effd206503df38a1328c9f1f957813/torch-2.4.0-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:7334325c0292cbd5c2eac085f449bf57d3690932eac37027e193ba775703c9e6", size = 89850473 },
+    { url = "https://files.pythonhosted.org/packages/18/cf/f69dff972a748e08e1bf602ef94ea5c6d4dd2f41cea22c8ad67a607d8b41/torch-2.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:97730014da4c57ffacb3c09298c6ce05400606e890bd7a05008d13dd086e46b1", size = 197860580 },
+    { url = "https://files.pythonhosted.org/packages/b7/d0/5e8f96d83889e77b478b90e7d8d24a5fc14c5c9350c6b93d071f45f39096/torch-2.4.0-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:f169b4ea6dc93b3a33319611fcc47dc1406e4dd539844dcbd2dec4c1b96e166d", size = 62144370 },
+    { url = "https://files.pythonhosted.org/packages/bf/55/b6c74df4695f94a9c3505021bc2bd662e271d028d055b3b2529f3442a3bd/torch-2.4.0-cp312-cp312-manylinux1_x86_64.whl", hash = "sha256:997084a0f9784d2a89095a6dc67c7925e21bf25dea0b3d069b41195016ccfcbb", size = 797168571 },
+    { url = "https://files.pythonhosted.org/packages/9a/5d/327fb72044c22d68a826643abf2e220db3d7f6005a41a6b167af1ffbc708/torch-2.4.0-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:bc3988e8b36d1e8b998d143255d9408d8c75da4ab6dd0dcfd23b623dfb0f0f57", size = 89746726 },
+    { url = "https://files.pythonhosted.org/packages/dc/95/a14dd84ce65e5ce176176393a80b2f74864ee134a31f590140456a4c0959/torch-2.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:3374128bbf7e62cdaed6c237bfd39809fbcfaa576bee91e904706840c3f2195c", size = 197807123 },
+    { url = "https://files.pythonhosted.org/packages/c7/87/489ebb234e75760e06fa4789fa6d4e13c125beefa1483ce35c9e43dcd395/torch-2.4.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:91aaf00bfe1ffa44dc5b52809d9a95129fca10212eca3ac26420eb11727c6288", size = 62123112 },
+]
+
+[[package]]
+name = "torch"
+version = "2.6.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "filelock", marker = "extra == 'extra-21-lematerial-forgebench-mace' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "fsspec", marker = "extra == 'extra-21-lematerial-forgebench-mace' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "jinja2", marker = "extra == 'extra-21-lematerial-forgebench-mace' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "networkx", marker = "extra == 'extra-21-lematerial-forgebench-mace' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "nvidia-cublas-cu12", version = "12.4.5.8", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-21-lematerial-forgebench-mace') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "nvidia-cuda-cupti-cu12", version = "12.4.127", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-21-lematerial-forgebench-mace') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "nvidia-cuda-nvrtc-cu12", version = "12.4.127", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-21-lematerial-forgebench-mace') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "nvidia-cuda-runtime-cu12", version = "12.4.127", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-21-lematerial-forgebench-mace') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "nvidia-cudnn-cu12", version = "9.1.0.70", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-21-lematerial-forgebench-mace') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "nvidia-cufft-cu12", version = "11.2.1.3", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-21-lematerial-forgebench-mace') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "nvidia-curand-cu12", version = "10.3.5.147", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-21-lematerial-forgebench-mace') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "nvidia-cusolver-cu12", version = "11.6.1.9", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-21-lematerial-forgebench-mace') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "nvidia-cusparse-cu12", version = "12.3.1.170", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-21-lematerial-forgebench-mace') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "nvidia-cusparselt-cu12", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-21-lematerial-forgebench-mace') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "nvidia-nccl-cu12", version = "2.21.5", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-21-lematerial-forgebench-mace') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "nvidia-nvjitlink-cu12", version = "12.4.127", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-21-lematerial-forgebench-mace') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "nvidia-nvtx-cu12", version = "12.4.127", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-21-lematerial-forgebench-mace') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "setuptools", marker = "(python_full_version >= '3.12' and extra == 'extra-21-lematerial-forgebench-mace') or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "sympy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-21-lematerial-forgebench-mace' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "triton", version = "3.2.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-21-lematerial-forgebench-mace') or (platform_machine != 'x86_64' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (sys_platform != 'linux' and extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace') or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+    { name = "typing-extensions", marker = "extra == 'extra-21-lematerial-forgebench-mace' or (extra == 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-orb')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/a9/97cbbc97002fff0de394a2da2cdfa859481fdca36996d7bd845d50aa9d8d/torch-2.6.0-cp311-cp311-manylinux1_x86_64.whl", hash = "sha256:7979834102cd5b7a43cc64e87f2f3b14bd0e1458f06e9f88ffa386d07c7446e1", size = 766715424 },
+    { url = "https://files.pythonhosted.org/packages/6d/fa/134ce8f8a7ea07f09588c9cc2cea0d69249efab977707cf67669431dcf5c/torch-2.6.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:ccbd0320411fe1a3b3fec7b4d3185aa7d0c52adac94480ab024b5c8f74a0bf1d", size = 95759416 },
+    { url = "https://files.pythonhosted.org/packages/11/c5/2370d96b31eb1841c3a0883a492c15278a6718ccad61bb6a649c80d1d9eb/torch-2.6.0-cp311-cp311-win_amd64.whl", hash = "sha256:46763dcb051180ce1ed23d1891d9b1598e07d051ce4c9d14307029809c4d64f7", size = 204164970 },
+    { url = "https://files.pythonhosted.org/packages/0b/fa/f33a4148c6fb46ca2a3f8de39c24d473822d5774d652b66ed9b1214da5f7/torch-2.6.0-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:94fc63b3b4bedd327af588696559f68c264440e2503cc9e6954019473d74ae21", size = 66530713 },
+    { url = "https://files.pythonhosted.org/packages/e5/35/0c52d708144c2deb595cd22819a609f78fdd699b95ff6f0ebcd456e3c7c1/torch-2.6.0-cp312-cp312-manylinux1_x86_64.whl", hash = "sha256:2bb8987f3bb1ef2675897034402373ddfc8f5ef0e156e2d8cfc47cacafdda4a9", size = 766624563 },
+    { url = "https://files.pythonhosted.org/packages/01/d6/455ab3fbb2c61c71c8842753b566012e1ed111e7a4c82e0e1c20d0c76b62/torch-2.6.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:b789069020c5588c70d5c2158ac0aa23fd24a028f34a8b4fcb8fcb4d7efcf5fb", size = 95607867 },
+    { url = "https://files.pythonhosted.org/packages/18/cf/ae99bd066571656185be0d88ee70abc58467b76f2f7c8bfeb48735a71fe6/torch-2.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:7e1448426d0ba3620408218b50aa6ada88aeae34f7a239ba5431f6c8774b1239", size = 204120469 },
+    { url = "https://files.pythonhosted.org/packages/81/b4/605ae4173aa37fb5aa14605d100ff31f4f5d49f617928c9f486bb3aaec08/torch-2.6.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:9a610afe216a85a8b9bc9f8365ed561535c93e804c2a317ef7fabcc5deda0989", size = 66532538 },
+    { url = "https://files.pythonhosted.org/packages/24/85/ead1349fc30fe5a32cadd947c91bda4a62fbfd7f8c34ee61f6398d38fb48/torch-2.6.0-cp313-cp313-manylinux1_x86_64.whl", hash = "sha256:4874a73507a300a5d089ceaff616a569e7bb7c613c56f37f63ec3ffac65259cf", size = 766626191 },
+    { url = "https://files.pythonhosted.org/packages/dd/b0/26f06f9428b250d856f6d512413e9e800b78625f63801cbba13957432036/torch-2.6.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a0d5e1b9874c1a6c25556840ab8920569a7a4137afa8a63a32cee0bc7d89bd4b", size = 95611439 },
+    { url = "https://files.pythonhosted.org/packages/c2/9c/fc5224e9770c83faed3a087112d73147cd7c7bfb7557dcf9ad87e1dda163/torch-2.6.0-cp313-cp313-win_amd64.whl", hash = "sha256:510c73251bee9ba02ae1cb6c9d4ee0907b3ce6020e62784e2d7598e0cfa4d6cc", size = 204126475 },
+    { url = "https://files.pythonhosted.org/packages/88/8b/d60c0491ab63634763be1537ad488694d316ddc4a20eaadd639cedc53971/torch-2.6.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:ff96f4038f8af9f7ec4231710ed4549da1bdebad95923953a25045dcf6fd87e2", size = 66536783 },
+]
+
+[[package]]
+name = "torch"
 version = "2.7.1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.13' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+]
 dependencies = [
     { name = "filelock" },
     { name = "fsspec" },
     { name = "jinja2" },
     { name = "networkx" },
-    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12", version = "12.6.4.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti-cu12", version = "12.6.80", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", version = "12.6.77", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", version = "12.6.77", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu12", version = "9.5.1.17", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufft-cu12", version = "11.3.0.4", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-curand-cu12", version = "10.3.7.77", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusolver-cu12", version = "11.7.1.2", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", version = "12.5.4.2", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu12", version = "0.6.3", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu12", version = "2.26.2", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", version = "12.6.85", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvtx-cu12", version = "12.6.77", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "setuptools", marker = "python_full_version >= '3.12'" },
-    { name = "sympy" },
-    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "sympy", version = "1.14.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "triton", version = "3.3.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "typing-extensions" },
 ]
 wheels = [
@@ -3048,15 +4254,214 @@ wheels = [
 ]
 
 [[package]]
+name = "torch-cluster"
+version = "1.6.3+pt24cu124"
+source = { registry = "https://data.pyg.org/whl/torch-2.4.0+cu124.html" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and sys_platform == 'linux'",
+    "python_full_version >= '3.12' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'linux'",
+    "python_full_version < '3.12' and sys_platform != 'linux' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "scipy" },
+]
+wheels = [
+    { url = "https://data.pyg.org/whl/torch-2.4.0%2Bcu124/torch_cluster-1.6.3%2Bpt24cu124-cp311-cp311-linux_x86_64.whl" },
+    { url = "https://data.pyg.org/whl/torch-2.4.0%2Bcu124/torch_cluster-1.6.3%2Bpt24cu124-cp311-cp311-win_amd64.whl" },
+    { url = "https://data.pyg.org/whl/torch-2.4.0%2Bcu124/torch_cluster-1.6.3%2Bpt24cu124-cp312-cp312-linux_x86_64.whl" },
+    { url = "https://data.pyg.org/whl/torch-2.4.0%2Bcu124/torch_cluster-1.6.3%2Bpt24cu124-cp312-cp312-win_amd64.whl" },
+]
+
+[[package]]
+name = "torch-cluster"
+version = "1.6.3+pt26cu124"
+source = { registry = "https://data.pyg.org/whl/torch-2.6.0+cu124.html" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.13' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+]
+dependencies = [
+    { name = "scipy" },
+]
+wheels = [
+    { url = "https://data.pyg.org/whl/torch-2.6.0%2Bcu124/torch_cluster-1.6.3%2Bpt26cu124-cp311-cp311-linux_x86_64.whl" },
+    { url = "https://data.pyg.org/whl/torch-2.6.0%2Bcu124/torch_cluster-1.6.3%2Bpt26cu124-cp311-cp311-win_amd64.whl" },
+    { url = "https://data.pyg.org/whl/torch-2.6.0%2Bcu124/torch_cluster-1.6.3%2Bpt26cu124-cp312-cp312-linux_x86_64.whl" },
+    { url = "https://data.pyg.org/whl/torch-2.6.0%2Bcu124/torch_cluster-1.6.3%2Bpt26cu124-cp312-cp312-win_amd64.whl" },
+]
+
+[[package]]
 name = "torch-ema"
 version = "0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "torch" },
+    { name = "torch", version = "2.6.0", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/45/af/db7d0c8b26a13062d9b85bdcf8d977acd8a51057fb6edca9eb30613ef5ef/torch_ema-0.3.tar.gz", hash = "sha256:5a3595405fa311995f01291a1d4a9242d6be08a0fc9db29152ec6cfd586ea414", size = 5486 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/f1/a47c831436595cffbfd69a19ea129a23627120b13f4886499e58775329d1/torch_ema-0.3-py3-none-any.whl", hash = "sha256:823ad8da5c10bc1eebcec739cc3f521aa9573229fe04e5673c304d29f1433279", size = 5475 },
+]
+
+[[package]]
+name = "torch-geometric"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "psutil" },
+    { name = "pyparsing" },
+    { name = "requests" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e6/6e/a596e2ddecc3b13a0d576495369a30309fb54c74fadf0bbca645bfbcaa2f/torch_geometric-2.4.0.tar.gz", hash = "sha256:343c6906d0678f16553c2d02b7267d0ec77eafb5b44324070ebcf7da8a934557", size = 689471 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/4e/6f9a75548a93fedcd4514ae2de9bee1e91bade6b73252b4da32f0e42ac52/torch_geometric-2.4.0-py3-none-any.whl", hash = "sha256:9d8eb5eec44382f4072aa5e835450f144e9edb9d164627e532e311880b6bdad0", size = 1033784 },
+]
+
+[[package]]
+name = "torch-scatter"
+version = "2.1.2+pt24cu124"
+source = { registry = "https://data.pyg.org/whl/torch-2.4.0+cu124.html" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and sys_platform == 'linux'",
+    "python_full_version >= '3.12' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'linux'",
+    "python_full_version < '3.12' and sys_platform != 'linux' and sys_platform != 'win32'",
+]
+wheels = [
+    { url = "https://data.pyg.org/whl/torch-2.4.0%2Bcu124/torch_scatter-2.1.2%2Bpt24cu124-cp311-cp311-linux_x86_64.whl" },
+    { url = "https://data.pyg.org/whl/torch-2.4.0%2Bcu124/torch_scatter-2.1.2%2Bpt24cu124-cp311-cp311-win_amd64.whl" },
+    { url = "https://data.pyg.org/whl/torch-2.4.0%2Bcu124/torch_scatter-2.1.2%2Bpt24cu124-cp312-cp312-linux_x86_64.whl" },
+    { url = "https://data.pyg.org/whl/torch-2.4.0%2Bcu124/torch_scatter-2.1.2%2Bpt24cu124-cp312-cp312-win_amd64.whl" },
+]
+
+[[package]]
+name = "torch-scatter"
+version = "2.1.2+pt26cu124"
+source = { registry = "https://data.pyg.org/whl/torch-2.6.0+cu124.html" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.13' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+]
+wheels = [
+    { url = "https://data.pyg.org/whl/torch-2.6.0%2Bcu124/torch_scatter-2.1.2%2Bpt26cu124-cp311-cp311-linux_x86_64.whl" },
+    { url = "https://data.pyg.org/whl/torch-2.6.0%2Bcu124/torch_scatter-2.1.2%2Bpt26cu124-cp311-cp311-win_amd64.whl" },
+    { url = "https://data.pyg.org/whl/torch-2.6.0%2Bcu124/torch_scatter-2.1.2%2Bpt26cu124-cp312-cp312-linux_x86_64.whl" },
+    { url = "https://data.pyg.org/whl/torch-2.6.0%2Bcu124/torch_scatter-2.1.2%2Bpt26cu124-cp312-cp312-win_amd64.whl" },
+]
+
+[[package]]
+name = "torch-sparse"
+version = "0.6.18+pt24cu124"
+source = { registry = "https://data.pyg.org/whl/torch-2.4.0+cu124.html" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and sys_platform == 'linux'",
+    "python_full_version >= '3.12' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'linux'",
+    "python_full_version < '3.12' and sys_platform != 'linux' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "scipy" },
+]
+wheels = [
+    { url = "https://data.pyg.org/whl/torch-2.4.0%2Bcu124/torch_sparse-0.6.18%2Bpt24cu124-cp311-cp311-linux_x86_64.whl" },
+    { url = "https://data.pyg.org/whl/torch-2.4.0%2Bcu124/torch_sparse-0.6.18%2Bpt24cu124-cp311-cp311-win_amd64.whl" },
+    { url = "https://data.pyg.org/whl/torch-2.4.0%2Bcu124/torch_sparse-0.6.18%2Bpt24cu124-cp312-cp312-linux_x86_64.whl" },
+    { url = "https://data.pyg.org/whl/torch-2.4.0%2Bcu124/torch_sparse-0.6.18%2Bpt24cu124-cp312-cp312-win_amd64.whl" },
+]
+
+[[package]]
+name = "torch-sparse"
+version = "0.6.18+pt26cu124"
+source = { registry = "https://data.pyg.org/whl/torch-2.6.0+cu124.html" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.13' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+]
+dependencies = [
+    { name = "scipy" },
+]
+wheels = [
+    { url = "https://data.pyg.org/whl/torch-2.6.0%2Bcu124/torch_sparse-0.6.18%2Bpt26cu124-cp311-cp311-linux_x86_64.whl" },
+    { url = "https://data.pyg.org/whl/torch-2.6.0%2Bcu124/torch_sparse-0.6.18%2Bpt26cu124-cp311-cp311-win_amd64.whl" },
+    { url = "https://data.pyg.org/whl/torch-2.6.0%2Bcu124/torch_sparse-0.6.18%2Bpt26cu124-cp312-cp312-linux_x86_64.whl" },
+    { url = "https://data.pyg.org/whl/torch-2.6.0%2Bcu124/torch_sparse-0.6.18%2Bpt26cu124-cp312-cp312-win_amd64.whl" },
+]
+
+[[package]]
+name = "torch-spline-conv"
+version = "1.2.2+pt24cu124"
+source = { registry = "https://data.pyg.org/whl/torch-2.4.0+cu124.html" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and sys_platform == 'linux'",
+    "python_full_version >= '3.12' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'linux'",
+    "python_full_version < '3.12' and sys_platform != 'linux' and sys_platform != 'win32'",
+]
+wheels = [
+    { url = "https://data.pyg.org/whl/torch-2.4.0%2Bcu124/torch_spline_conv-1.2.2%2Bpt24cu124-cp311-cp311-linux_x86_64.whl" },
+    { url = "https://data.pyg.org/whl/torch-2.4.0%2Bcu124/torch_spline_conv-1.2.2%2Bpt24cu124-cp311-cp311-win_amd64.whl" },
+    { url = "https://data.pyg.org/whl/torch-2.4.0%2Bcu124/torch_spline_conv-1.2.2%2Bpt24cu124-cp312-cp312-linux_x86_64.whl" },
+    { url = "https://data.pyg.org/whl/torch-2.4.0%2Bcu124/torch_spline_conv-1.2.2%2Bpt24cu124-cp312-cp312-win_amd64.whl" },
+]
+
+[[package]]
+name = "torch-spline-conv"
+version = "1.2.2+pt26cu124"
+source = { registry = "https://data.pyg.org/whl/torch-2.6.0+cu124.html" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.13' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform == 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra == 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+]
+wheels = [
+    { url = "https://data.pyg.org/whl/torch-2.6.0%2Bcu124/torch_spline_conv-1.2.2%2Bpt26cu124-cp311-cp311-linux_x86_64.whl" },
+    { url = "https://data.pyg.org/whl/torch-2.6.0%2Bcu124/torch_spline_conv-1.2.2%2Bpt26cu124-cp311-cp311-win_amd64.whl" },
+    { url = "https://data.pyg.org/whl/torch-2.6.0%2Bcu124/torch_spline_conv-1.2.2%2Bpt26cu124-cp312-cp312-linux_x86_64.whl" },
+    { url = "https://data.pyg.org/whl/torch-2.6.0%2Bcu124/torch_spline_conv-1.2.2%2Bpt26cu124-cp312-cp312-win_amd64.whl" },
 ]
 
 [[package]]
@@ -3065,13 +4470,35 @@ version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lightning-utilities" },
-    { name = "numpy" },
+    { name = "numpy", version = "2.2.3", source = { registry = "https://pypi.org/simple" } },
     { name = "packaging" },
-    { name = "torch" },
+    { name = "torch", version = "2.6.0", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b7/ec/f5a4f94c77a1b4c0a37e5c5c8b666a33bc074130258a6b655346bec560c2/torchmetrics-1.7.2.tar.gz", hash = "sha256:ba401cd01aeaa268e809c0e4f42ef8f95669bf9b485e1d93d54dc765e012338a", size = 566185 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/89/b5fd7eb99b27457d71d3b7d9eca0b884fa5992abca7672aab1177c5f22d8/torchmetrics-1.7.2-py3-none-any.whl", hash = "sha256:9cc3bff07a715fcb37fb04d2a1a5ae36267c36066c097578020056653a94f2a8", size = 962510 },
+]
+
+[[package]]
+name = "torchtnt"
+version = "0.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fsspec" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyre-extensions" },
+    { name = "setuptools" },
+    { name = "tabulate" },
+    { name = "tensorboard" },
+    { name = "torch", version = "2.4.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3c/b9/c440c3bf39edddf1b72cbf88245a8ca3345caae0cbeabb2601ddcc679be5/torchtnt-0.2.4.tar.gz", hash = "sha256:26cf4e718965afc293e76158b47283722055bcf79e94d0e67e70b5dbf61c0c9b", size = 115176 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/20/d8b33d11f38515ef88a84ac32e1809de110440278cd35c30d3f1ca511397/torchtnt-0.2.4-py3-none-any.whl", hash = "sha256:c9b738232090c5e3453f202b1feb45e23d5cd2f23a04ca8b53e9b28ad3755ddb", size = 163459 },
 ]
 
 [[package]]
@@ -3097,8 +4524,45 @@ wheels = [
 
 [[package]]
 name = "triton"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'linux'",
+    "python_full_version < '3.12' and sys_platform == 'linux'",
+]
+dependencies = [
+    { name = "filelock", marker = "extra == 'extra-21-lematerial-forgebench-fairchem' or (extra == 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/3e/a2f59384587eff6aeb7d37b6780de7fedd2214935e27520430ca9f5b7975/triton-3.0.0-1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ce8520437c602fb633f1324cc3871c47bee3b67acf9756c1a66309b60e3216c", size = 209438883 },
+    { url = "https://files.pythonhosted.org/packages/fe/7b/7757205dee3628f75e7991021d15cd1bd0c9b044ca9affe99b50879fc0e1/triton-3.0.0-1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:34e509deb77f1c067d8640725ef00c5cbfcb2052a1a3cb6a6d343841f92624eb", size = 209464695 },
+]
+
+[[package]]
+name = "triton"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform != 'win32'",
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/2e/757d2280d4fefe7d33af7615124e7e298ae7b8e3bc4446cdb8e88b0f9bab/triton-3.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8009a1fb093ee8546495e96731336a33fb8856a38e45bb4ab6affd6dbc3ba220", size = 253157636 },
+    { url = "https://files.pythonhosted.org/packages/06/00/59500052cb1cf8cf5316be93598946bc451f14072c6ff256904428eaf03c/triton-3.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d9b215efc1c26fa7eefb9a157915c92d52e000d2bf83e5f69704047e63f125c", size = 253159365 },
+    { url = "https://files.pythonhosted.org/packages/c7/30/37a3384d1e2e9320331baca41e835e90a3767303642c7a80d4510152cbcf/triton-3.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e5dfa23ba84541d7c0a531dfce76d8bcd19159d50a4a8b14ad01e91734a5c1b0", size = 253154278 },
+]
+
+[[package]]
+name = "triton"
 version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra == 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version >= '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+    "python_full_version < '3.12' and sys_platform != 'win32' and extra != 'extra-21-lematerial-forgebench-fairchem' and extra != 'extra-21-lematerial-forgebench-mace' and extra != 'extra-21-lematerial-forgebench-orb'",
+]
 dependencies = [
     { name = "setuptools", marker = "sys_platform != 'win32'" },
 ]
@@ -3116,6 +4580,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d1/bc/51647cd02527e87d05cb083ccc402f93e441606ff1f01739a62c8ad09ba5/typing_extensions-4.14.0.tar.gz", hash = "sha256:8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4", size = 107423 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/e0/552843e0d356fbb5256d21449fa957fa4eff3bbc135a74a691ee70c7c5da/typing_extensions-4.14.0-py3-none-any.whl", hash = "sha256:a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af", size = 43839 },
+]
+
+[[package]]
+name = "typing-inspect"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mypy-extensions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/74/1789779d91f1961fa9438e9a8710cdae6bd138c80d7303996933d117264a/typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78", size = 13825 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl", hash = "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f", size = 8827 },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/b1/0c11f5058406b3af7609f121aaa6b609744687f1d158b3c3a5bf4cc94238/typing_inspection-0.4.1.tar.gz", hash = "sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28", size = 75726 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/69/cd203477f944c353c31bade965f880aa1061fd6bf05ded0726ca845b6ff7/typing_inspection-0.4.1-py3-none-any.whl", hash = "sha256:389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51", size = 14552 },
 ]
 
 [[package]]
@@ -3160,12 +4649,56 @@ wheels = [
 ]
 
 [[package]]
+name = "wandb"
+version = "0.20.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "gitpython" },
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "protobuf" },
+    { name = "psutil" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "sentry-sdk" },
+    { name = "setproctitle" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/1f/92be0ca87fb49eb48c16dcf0845a3579a57c4734fec2b95862cf5a0494a0/wandb-0.20.1.tar.gz", hash = "sha256:dbd3fc60dfe7bf83c4de24b206b99b44949fef323f817a783883db72fc5f3bfe", size = 40320062 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/18/afcc37d0b93dd6f6d0f0c5683b9cfff9416ae1539931f58932a2938c0070/wandb-0.20.1-py3-none-any.whl", hash = "sha256:e6395cabf074247042be1cf0dc6ab0b06aa4c9538c2e1fdc5b507a690ce0cf17", size = 6458872 },
+    { url = "https://files.pythonhosted.org/packages/e6/b5/70f9e2a3d1380b729ae5853763d938edc50072df357f79bbd19b9aae8e3f/wandb-0.20.1-py3-none-macosx_10_14_x86_64.whl", hash = "sha256:2475a48c693adf677d40da9e1c8ceeaf86d745ffc3b7e3535731279d02f9e845", size = 22517483 },
+    { url = "https://files.pythonhosted.org/packages/cc/7e/4eb9aeb2fd974d410a8f2eb11b0219536503913a050d46a03206151705c8/wandb-0.20.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:99cce804c31ec1e0d1e691650a7d51773ed7329c41745d56384fa3655a0e9b2c", size = 22034511 },
+    { url = "https://files.pythonhosted.org/packages/34/38/1df22c2273e6f7ab0aae4fd032085d6d92ab112f5b261646e7dc5e675cfe/wandb-0.20.1-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:ce3ee412677a1679e04b21e03a91e1e02eb90faf658d682bee86c33cf5f32e09", size = 22720771 },
+    { url = "https://files.pythonhosted.org/packages/38/96/78fc7a7ea7158d136c84f481423f8736c9346a2387287ec8a6d92019975c/wandb-0.20.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5e58ca32c7147161158f09b0fb5f5896876f8569d0d10ae7b64d0510c868ce33", size = 21537453 },
+    { url = "https://files.pythonhosted.org/packages/88/c9/41b8bdb493e5eda32b502bc1cc49d539335a92cacaf0ef304d7dae0240aa/wandb-0.20.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:591506ecbdd396648cc323ba270f3ab4aed3158e1dbfa7636c09f9f7f0253e1c", size = 23161349 },
+    { url = "https://files.pythonhosted.org/packages/7d/f2/79e783cc50a47d373dfbda862eb5396de8139167e8c6443a16ef0166106f/wandb-0.20.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:382508532db09893f81cc926b1d333caa4c8a7db057878899fadf929bbdb3b56", size = 21550624 },
+    { url = "https://files.pythonhosted.org/packages/26/32/23890a726302e7be28bda9fff47ce9b491af64e339aba4d32b3b8d1a7aaf/wandb-0.20.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:29ea495e49393db860f17437fe37e48018da90436ce10949b471780f09293bd7", size = 23237996 },
+    { url = "https://files.pythonhosted.org/packages/af/94/296e520b086b2a4f10e99bcea3cd5856421b9c004824663501e3789a713b/wandb-0.20.1-py3-none-win32.whl", hash = "sha256:455ee0a652e59ab1e4b546fa1dc833dd3063aa7e64eb8abf95d22f0e9f08c574", size = 22518456 },
+    { url = "https://files.pythonhosted.org/packages/52/5f/c44ad7b2a062ca5f4da99ae475cea274c38f6ec37bdaca1b1c653ee87274/wandb-0.20.1-py3-none-win_amd64.whl", hash = "sha256:6d2431652f096b7e394c29a99135a6441c02ed3198b963f0b351a5b5e56aeca0", size = 22518459 },
+]
+
+[[package]]
 name = "wcwidth"
 version = "0.2.13"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5", size = 101301 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859", size = 34166 },
+]
+
+[[package]]
+name = "werkzeug"
+version = "3.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/69/83029f1f6300c5fb2471d621ab06f6ec6b3324685a2ce0f9777fd4a8b71e/werkzeug-3.1.3.tar.gz", hash = "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746", size = 806925 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/24/ab44c871b0f07f491e5d2ad12c9bd7358e527510618cb1b803a88e986db1/werkzeug-3.1.3-py3-none-any.whl", hash = "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e", size = 224498 },
 ]
 
 [[package]]


### PR DESCRIPTION
Splitted the different dependencies, as there is no other way to solve the conflicting dependencies:
```bash
uv sync --extra <model> # model in ["mace", "orb", "fairchem"]
```