### PR TITLE
fix: update hasher to sync with LeMat-Bulk configuration

### DIFF
--- a/src/lematerial_forgebench/metrics/novelty_metric.py
+++ b/src/lematerial_forgebench/metrics/novelty_metric.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional, Set
 import numpy as np
 from datasets import load_dataset
 from material_hasher.hasher.bawl import BAWLHasher
+from pymatgen.analysis.local_env import EconNN, NearNeighbors
 from pymatgen.core.structure import Structure
 
 from lematerial_forgebench.metrics.base import BaseMetric, MetricConfig
@@ -119,7 +120,18 @@ class NoveltyMetric(BaseMetric):
     def _init_fingerprinter(self) -> None:
         """Initialize the fingerprinting method."""
         if self.config.fingerprint_method.lower() == "bawl":
-            self.fingerprinter = BAWLHasher()
+            self.fingerprinter = BAWLHasher(
+                graphing_algorithm="WL",
+                bonding_algorithm=EconNN,
+                bonding_kwargs={
+                    "tol": 0.2,
+                    "cutoff": 10,
+                    "use_fictive_radius": True,
+                },
+                include_composition=True,
+                symmetry_labeling="SPGLib",
+                shorten_hash=False,
+            )
         else:
             raise ValueError(
                 f"Unknown fingerprint method: {self.config.fingerprint_method}. "

--- a/src/lematerial_forgebench/metrics/uniqueness_metric.py
+++ b/src/lematerial_forgebench/metrics/uniqueness_metric.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, List
 
 from material_hasher.hasher.bawl import BAWLHasher
+from pymatgen.analysis.local_env import EconNN, NearNeighbors
 from pymatgen.core.structure import Structure
 
 from lematerial_forgebench.metrics.base import BaseMetric, MetricConfig, MetricResult
@@ -84,7 +85,18 @@ class UniquenessMetric(BaseMetric):
     def _init_fingerprinter(self) -> None:
         """Initialize the fingerprinting method."""
         if self.config.fingerprint_method.lower() == "bawl":
-            self.fingerprinter = BAWLHasher()
+            self.fingerprinter = BAWLHasher(
+                graphing_algorithm="WL",
+                bonding_algorithm=EconNN,
+                bonding_kwargs={
+                    "tol": 0.2,
+                    "cutoff": 10,
+                    "use_fictive_radius": True,
+                },
+                include_composition=True,
+                symmetry_labeling="SPGLib",
+                shorten_hash=False,
+            )
         else:
             raise ValueError(
                 f"Unknown fingerprint method: {self.config.fingerprint_method}. "


### PR DESCRIPTION
@Ramlaoui had pointed out that the hashes available on LeMat-Bulk do not use the default `BAWLHasher()`, rather the following configuration:
```python
hasher = BAWLHasher(graphing_algorithm: str = "WL",
        bonding_algorithm: NearNeighbors = EconNN,
        bonding_kwargs: dict = {"tol": 0.2, "cutoff": 10, "use_fictive_radius": True},
        include_composition: bool = True,
        symmetry_labeling: str = "SPGLib",
        shorten_hash: bool = False,
    )
```
Hence, making this change via the PR. addresses #34 