### PR TITLE
Fix/atomic density validity

### DIFF
--- a/scripts/extract_density_range.py
+++ b/scripts/extract_density_range.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import pandas as pd 
-import matplotlib.pyplot as plt 
+import matplotlib.pyplot as plt
+import pandas as pd
 
 if __name__ == "__main__":
     density_df = pd.read_csv("/home/samue/lemat-genbench/data/lematbulk_density_properties.csv")

--- a/scripts/extract_density_range.py
+++ b/scripts/extract_density_range.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import pandas as pd 
+import matplotlib.pyplot as plt 
+
+if __name__ == "__main__":
+    density_df = pd.read_csv("/home/samue/lemat-genbench/data/lematbulk_density_properties.csv")
+    plt.hist(density_df["Density(atoms/A^3)"])
+    plt.savefig("atomic_density_hist.png")
+    plt.clf()
+    plt.hist(density_df["Density(g/cm^3)"])
+    plt.savefig("mass_density_hist.png")
+    plt.clf()
+    print(max(density_df["Density(atoms/A^3)"]))
+    print(min(density_df["Density(atoms/A^3)"]))

--- a/scripts/run_benchmarks.py
+++ b/scripts/run_benchmarks.py
@@ -415,9 +415,12 @@ def run_validity_preprocessing_and_filtering(
     start_time = time.time()
 
     validity_settings = config.get("validity_settings", {})
+    print(validity_settings)
     validity_benchmark = ValidityBenchmark(
         charge_tolerance=validity_settings.get("charge_tolerance", 0.1),
         distance_scaling=validity_settings.get("distance_scaling", 0.5),
+        min_atomic_density=validity_settings.get("min_atomic_density", 0.00001),
+        max_atomic_density=validity_settings.get("max_atomic_density", 0.5),
         min_mass_density=validity_settings.get("min_mass_density", 0.01),
         max_mass_density=validity_settings.get("max_mass_density", 25.0),
         check_format=validity_settings.get("check_format", True),
@@ -440,6 +443,8 @@ def run_validity_preprocessing_and_filtering(
 
     charge_tolerance = validity_settings.get("charge_tolerance", 0.1)
     distance_scaling = validity_settings.get("distance_scaling", 0.5)
+    min_atomic_density=validity_settings.get("min_atomic_density", 0.00001),
+    max_atomic_density=validity_settings.get("max_atomic_density", 0.5),
     min_mass_density = validity_settings.get("min_mass_density", 0.01)
     max_mass_density = validity_settings.get("max_mass_density", 25.0)
     check_format = validity_settings.get("check_format", True)
@@ -448,6 +453,8 @@ def run_validity_preprocessing_and_filtering(
     validity_preprocessor = ValidityPreprocessor(
         charge_tolerance=charge_tolerance,
         distance_scaling_factor=distance_scaling,
+        plausibility_min_atomic_density=min_atomic_density,
+        plausibility_max_atomic_density=max_atomic_density,
         plausibility_min_mass_density=min_mass_density,
         plausibility_max_mass_density=max_mass_density,
         plausibility_check_format=check_format,

--- a/scripts/run_benchmarks.py
+++ b/scripts/run_benchmarks.py
@@ -415,7 +415,6 @@ def run_validity_preprocessing_and_filtering(
     start_time = time.time()
 
     validity_settings = config.get("validity_settings", {})
-    print(validity_settings)
     validity_benchmark = ValidityBenchmark(
         charge_tolerance=validity_settings.get("charge_tolerance", 0.1),
         distance_scaling=validity_settings.get("distance_scaling", 0.5),
@@ -426,9 +425,11 @@ def run_validity_preprocessing_and_filtering(
         check_format=validity_settings.get("check_format", True),
         check_symmetry=validity_settings.get("check_symmetry", True),
     )
-
     validity_benchmark_result = validity_benchmark.evaluate(structures)
-
+    print("num phyiscally plausible structures")
+    print(validity_benchmark_result.evaluator_results["physical_plausibility"]["metric_results"]
+          ["plausibility"].metrics["plausibility_valid_count"])
+    
     elapsed_time = time.time() - start_time
     logger.info(
         f"✅ MANDATORY validity benchmark complete for {n_total_structures} structures in {elapsed_time:.1f}s"
@@ -443,8 +444,8 @@ def run_validity_preprocessing_and_filtering(
 
     charge_tolerance = validity_settings.get("charge_tolerance", 0.1)
     distance_scaling = validity_settings.get("distance_scaling", 0.5)
-    min_atomic_density=validity_settings.get("min_atomic_density", 0.00001),
-    max_atomic_density=validity_settings.get("max_atomic_density", 0.5),
+    min_atomic_density=validity_settings.get("min_atomic_density", 0.00001)
+    max_atomic_density=validity_settings.get("max_atomic_density", 0.5)
     min_mass_density = validity_settings.get("min_mass_density", 0.01)
     max_mass_density = validity_settings.get("max_mass_density", 25.0)
     check_format = validity_settings.get("check_format", True)

--- a/scripts/run_benchmarks.py
+++ b/scripts/run_benchmarks.py
@@ -44,7 +44,6 @@ from lemat_genbench.benchmarks.sun_benchmark import (
     SUNBenchmark,  # Updated SUN benchmark
 )
 from lemat_genbench.benchmarks.uniqueness_benchmark import UniquenessBenchmark
-from lemat_genbench.benchmarks.validity_benchmark import ValidityBenchmark
 from lemat_genbench.preprocess.distribution_preprocess import DistributionPreprocessor
 from lemat_genbench.preprocess.fingerprint_preprocess import FingerprintPreprocessor
 from lemat_genbench.preprocess.multi_mlip_preprocess import (
@@ -395,7 +394,7 @@ def create_preprocessor_config(
 def run_validity_preprocessing_and_filtering(
     structures, config: Dict[str, Any], monitor_memory: bool = False
 ):
-    """Run validity benchmark and preprocessing, then filter to valid structures only.
+    """Run validity preprocessing and generate benchmark result, then filter to valid structures only.
 
     Returns
     -------
@@ -410,42 +409,15 @@ def run_validity_preprocessing_and_filtering(
         f"🔍 Starting MANDATORY validity processing for {n_total_structures} structures..."
     )
 
-    # Step 1: Run validity benchmark on ALL structures
-    logger.info("🔍 Running MANDATORY validity benchmark on ALL structures...")
-    start_time = time.time()
-
-    validity_settings = config.get("validity_settings", {})
-    validity_benchmark = ValidityBenchmark(
-        charge_tolerance=validity_settings.get("charge_tolerance", 0.1),
-        distance_scaling=validity_settings.get("distance_scaling", 0.5),
-        min_atomic_density=validity_settings.get("min_atomic_density", 0.00001),
-        max_atomic_density=validity_settings.get("max_atomic_density", 0.5),
-        min_mass_density=validity_settings.get("min_mass_density", 0.01),
-        max_mass_density=validity_settings.get("max_mass_density", 25.0),
-        check_format=validity_settings.get("check_format", True),
-        check_symmetry=validity_settings.get("check_symmetry", True),
-    )
-    validity_benchmark_result = validity_benchmark.evaluate(structures)
-    print("num phyiscally plausible structures")
-    print(validity_benchmark_result.evaluator_results["physical_plausibility"]["metric_results"]
-          ["plausibility"].metrics["plausibility_valid_count"])
-    
-    elapsed_time = time.time() - start_time
-    logger.info(
-        f"✅ MANDATORY validity benchmark complete for {n_total_structures} structures in {elapsed_time:.1f}s"
-    )
-
-    # Clean up after validity benchmark
-    cleanup_after_benchmark("validity", monitor_memory)
-
-    # Step 2: Run validity preprocessor on ALL structures
+    # Run validity preprocessor on ALL structures (replaces both benchmark and preprocessor)
     logger.info("🔍 Running MANDATORY validity preprocessor on ALL structures...")
     start_time = time.time()
 
+    validity_settings = config.get("validity_settings", {})
     charge_tolerance = validity_settings.get("charge_tolerance", 0.1)
     distance_scaling = validity_settings.get("distance_scaling", 0.5)
-    min_atomic_density=validity_settings.get("min_atomic_density", 0.00001)
-    max_atomic_density=validity_settings.get("max_atomic_density", 0.5)
+    min_atomic_density = validity_settings.get("min_atomic_density", 0.00001)
+    max_atomic_density = validity_settings.get("max_atomic_density", 0.5)
     min_mass_density = validity_settings.get("min_mass_density", 0.01)
     max_mass_density = validity_settings.get("max_mass_density", 25.0)
     check_format = validity_settings.get("check_format", True)
@@ -469,12 +441,15 @@ def run_validity_preprocessing_and_filtering(
     )
     processed_structures = validity_preprocessor_result.processed_structures
 
+    # Generate benchmark result from preprocessor data
+    validity_benchmark_result = validity_preprocessor.generate_benchmark_result(validity_preprocessor_result)
+
     elapsed_time = time.time() - start_time
     logger.info(
-        f"✅ MANDATORY validity preprocessing complete for {len(processed_structures)} structures in {elapsed_time:.1f}s"
+        f"✅ MANDATORY validity processing complete for {n_total_structures} structures in {elapsed_time:.1f}s"
     )
 
-    # Clean up after validity preprocessor
+    # Clean up after validity processing
     cleanup_after_preprocessor("validity", monitor_memory)
 
     # Step 3: Filter to only valid structures
@@ -929,10 +904,11 @@ def main():
         logger.info(f"Loading benchmark configuration: {args.config}")
         config = load_benchmark_config(args.config)
         
-        # Add fingerprint method to config
-        config["fingerprint_method"] = args.fingerprint_method
+        # Add fingerprint method to config (use config file value as default, override with command line if provided)
+        if args.fingerprint_method != "short-bawl":  # Only override if explicitly specified
+            config["fingerprint_method"] = args.fingerprint_method
         logger.info(f"✅ Loaded configuration: {config.get('type', 'unknown')}")
-        logger.info(f"🔍 Using fingerprint method: {args.fingerprint_method}")
+        logger.info(f"🔍 Using fingerprint method: {config.get('fingerprint_method', args.fingerprint_method)}")
 
         # Determine benchmark families to run
         if args.families:
@@ -1052,7 +1028,7 @@ def main():
             f"📊 Invalid structures: {validity_filtering_metadata['invalid_structures']}"
         )
         print(f"📊 Validity rate: {validity_filtering_metadata['validity_rate']:.1%}")
-        print(f"🔍 Fingerprint method: {args.fingerprint_method}")
+        print(f"🔍 Fingerprint method: {config.get('fingerprint_method', args.fingerprint_method)}")
         print(
             f"🔧 Benchmark families: {['validity (ALL structures)'] + [f'{family} (valid structures only)' for family in benchmark_families if family != 'validity']}"
         )

--- a/scripts/run_benchmarks.py
+++ b/scripts/run_benchmarks.py
@@ -418,8 +418,8 @@ def run_validity_preprocessing_and_filtering(
     validity_benchmark = ValidityBenchmark(
         charge_tolerance=validity_settings.get("charge_tolerance", 0.1),
         distance_scaling=validity_settings.get("distance_scaling", 0.5),
-        min_density=validity_settings.get("min_density", 0.01),
-        max_density=validity_settings.get("max_density", 25.0),
+        min_mass_density=validity_settings.get("min_mass_density", 0.01),
+        max_mass_density=validity_settings.get("max_mass_density", 25.0),
         check_format=validity_settings.get("check_format", True),
         check_symmetry=validity_settings.get("check_symmetry", True),
     )
@@ -440,16 +440,16 @@ def run_validity_preprocessing_and_filtering(
 
     charge_tolerance = validity_settings.get("charge_tolerance", 0.1)
     distance_scaling = validity_settings.get("distance_scaling", 0.5)
-    min_density = validity_settings.get("min_density", 0.01)
-    max_density = validity_settings.get("max_density", 25.0)
+    min_mass_density = validity_settings.get("min_mass_density", 0.01)
+    max_mass_density = validity_settings.get("max_mass_density", 25.0)
     check_format = validity_settings.get("check_format", True)
     check_symmetry = validity_settings.get("check_symmetry", True)
 
     validity_preprocessor = ValidityPreprocessor(
         charge_tolerance=charge_tolerance,
         distance_scaling_factor=distance_scaling,
-        plausibility_min_density=min_density,
-        plausibility_max_density=max_density,
+        plausibility_min_mass_density=min_mass_density,
+        plausibility_max_mass_density=max_mass_density,
         plausibility_check_format=check_format,
         plausibility_check_symmetry=check_symmetry,
     )

--- a/src/config/comprehensive.yaml
+++ b/src/config/comprehensive.yaml
@@ -8,8 +8,10 @@ type: comprehensive
 validity_settings:
   charge_tolerance: 0.1
   distance_scaling: 0.5
-  min_density: 0.01
-  max_density: 25.0
+  min_atomic_density: 0.00001
+  max_atomic_density: 0.5
+  min_mass_density: 0.01
+  max_mass_density: 25.0
   check_format: true
   check_symmetry: true
 

--- a/src/config/comprehensive_bawl.yaml
+++ b/src/config/comprehensive_bawl.yaml
@@ -8,8 +8,10 @@ type: comprehensive
 validity_settings:
   charge_tolerance: 0.1
   distance_scaling: 0.5
-  min_density: 0.01
-  max_density: 25.0
+  min_atomic_density: 0.00001
+  max_atomic_density: 0.5
+  min_mass_density: 0.01
+  max_mass_density: 25.0
   check_format: true
   check_symmetry: true
 

--- a/src/config/comprehensive_new.yaml
+++ b/src/config/comprehensive_new.yaml
@@ -8,8 +8,10 @@ type: comprehensive
 validity_settings:
   charge_tolerance: 0.1
   distance_scaling: 0.5
-  min_density: 0.01
-  max_density: 25.0
+  min_atomic_density: 0.00001
+  max_atomic_density: 0.5
+  min_mass_density: 0.01
+  max_mass_density: 25.0
   check_format: true
   check_symmetry: true
 

--- a/src/config/comprehensive_structure_matcher.yaml
+++ b/src/config/comprehensive_structure_matcher.yaml
@@ -8,8 +8,10 @@ type: comprehensive
 validity_settings:
   charge_tolerance: 0.1
   distance_scaling: 0.5
-  min_density: 0.01
-  max_density: 25.0
+  min_atomic_density: 0.00001
+  max_atomic_density: 0.5
+  min_mass_density: 0.01
+  max_mass_density: 25.0
   check_format: true
   check_symmetry: true
 

--- a/src/config/validity.yaml
+++ b/src/config/validity.yaml
@@ -3,7 +3,9 @@ description: "Validity Benchmark for Materials Generation"
 version: "0.2.0"
 charge_tolerance: 0.1
 distance_scaling: 0.5
-min_density: 0.01
-max_density: 25.0
+min_atomic_density: 0.00001
+max_atomic_density: 0.5
+min_mass_density: 0.01
+max_mass_density: 25.0
 check_format: true
 check_symmetry: true

--- a/src/lemat_genbench/benchmarks/validity_benchmark.py
+++ b/src/lemat_genbench/benchmarks/validity_benchmark.py
@@ -28,8 +28,8 @@ class ValidityBenchmark(BaseBenchmark):
         self,
         charge_tolerance: float = 0.1,
         distance_scaling: float = 0.5,
-        min_density: float = 0.01,
-        max_density: float = 25.0,
+        min_mass_density: float = 0.01,
+        max_mass_density: float = 25.0,
         check_format: bool = True,
         check_symmetry: bool = True,
         name: str = "ValidityBenchmark",
@@ -47,16 +47,16 @@ class ValidityBenchmark(BaseBenchmark):
         charge_metric = ChargeNeutralityMetric(tolerance=charge_tolerance)
         distance_metric = MinimumInteratomicDistanceMetric(scaling_factor=distance_scaling)
         plausibility_metric = PhysicalPlausibilityMetric(
-            min_density=min_density,
-            max_density=max_density,
+            min_mass_density=min_mass_density,
+            max_mass_density=max_mass_density,
             check_format=check_format,
             check_symmetry=check_symmetry,
         )
         overall_metric = OverallValidityMetric(
             charge_tolerance=charge_tolerance,
             distance_scaling=distance_scaling,
-            min_density=min_density,
-            max_density=max_density,
+            min_mass_density=min_mass_density,
+            max_mass_density=max_mass_density,
             check_format=check_format,
             check_symmetry=check_symmetry,
         )

--- a/src/lemat_genbench/benchmarks/validity_benchmark.py
+++ b/src/lemat_genbench/benchmarks/validity_benchmark.py
@@ -178,3 +178,20 @@ class ValidityBenchmark(BaseBenchmark):
         })
 
         return final_scores
+    
+
+if __name__ == "__main__":
+    from pymatgen.util.testing import PymatgenTest
+
+    test = PymatgenTest()
+
+    structures = [
+        test.get_structure("Si"),
+        test.get_structure("LiFePO4"),
+    ]
+
+    benchmark = ValidityBenchmark()
+    benchmark_result = benchmark.evaluate(structures)
+    print("num phyiscally plausible structures")
+    print(benchmark_result.evaluator_results["physical_plausibility"]["metric_results"]
+          ["plausibility"].metrics["plausibility_valid_count"])

--- a/src/lemat_genbench/benchmarks/validity_benchmark.py
+++ b/src/lemat_genbench/benchmarks/validity_benchmark.py
@@ -28,6 +28,8 @@ class ValidityBenchmark(BaseBenchmark):
         self,
         charge_tolerance: float = 0.1,
         distance_scaling: float = 0.5,
+        min_atomic_density: float = 0.00001,
+        max_atomic_density: float = 0.5,
         min_mass_density: float = 0.01,
         max_mass_density: float = 25.0,
         check_format: bool = True,
@@ -47,6 +49,8 @@ class ValidityBenchmark(BaseBenchmark):
         charge_metric = ChargeNeutralityMetric(tolerance=charge_tolerance)
         distance_metric = MinimumInteratomicDistanceMetric(scaling_factor=distance_scaling)
         plausibility_metric = PhysicalPlausibilityMetric(
+            min_atomic_density=min_atomic_density,
+            max_atomic_density=max_atomic_density,
             min_mass_density=min_mass_density,
             max_mass_density=max_mass_density,
             check_format=check_format,
@@ -55,6 +59,8 @@ class ValidityBenchmark(BaseBenchmark):
         overall_metric = OverallValidityMetric(
             charge_tolerance=charge_tolerance,
             distance_scaling=distance_scaling,
+            min_atomic_density=min_atomic_density,
+            max_atomic_density=max_atomic_density,
             min_mass_density=min_mass_density,
             max_mass_density=max_mass_density,
             check_format=check_format,

--- a/src/lemat_genbench/cli.py
+++ b/src/lemat_genbench/cli.py
@@ -81,8 +81,10 @@ def load_benchmark_config(config_name: str) -> dict:
             # Individual metric configurations
             "charge_tolerance": 0.1,
             "distance_scaling": 0.5,
-            "min_density": 0.01,
-            "max_density": 25.0,
+            "min_atomic_density": 0.00001,
+            "max_atomic_density": 0.5,
+            "min_mass_density": 0.01,
+            "max_mass_density": 25.0,
             "check_format": True,
             "check_symmetry": True,
             # Note: No weights needed - overall validity is intersection of all checks
@@ -206,8 +208,10 @@ def load_benchmark_config(config_name: str) -> dict:
                     "config": {
                         "charge_tolerance": 0.1,
                         "distance_scaling": 0.5,
-                        "min_density": 0.01,
-                        "max_density": 25.0,
+                        "min_atomic_density": 0.00001,
+                        "max_atomic_density": 0.5,
+                        "min_mass_density": 0.01,
+                        "max_mass_density": 25.0,
                         "check_format": True,
                         "check_symmetry": True,
                     },
@@ -337,8 +341,10 @@ def main(input: str, config_name: str, output: str):
             # Extract validity parameters (no weights needed)
             charge_tolerance = config.get("charge_tolerance", 0.1)
             distance_scaling = config.get("distance_scaling", 0.5)
-            min_density = config.get("min_density", 0.01)
-            max_density = config.get("max_density", 25.0)
+            min_atomic_density = config.get("min_atomic_density", 0.00001)
+            max_atomic_density = config.get("max_atomic_density", 0.5)
+            min_mass_density = config.get("min_mass_density", 0.01)
+            max_mass_density = config.get("max_mass_density", 25.0)
             check_format = config.get("check_format", True)
             check_symmetry = config.get("check_symmetry", True)
 
@@ -346,8 +352,10 @@ def main(input: str, config_name: str, output: str):
             benchmark = ValidityBenchmark(
                 charge_tolerance=charge_tolerance,
                 distance_scaling=distance_scaling,
-                min_density=min_density,
-                max_density=max_density,
+                min_atomic_density=min_atomic_density,
+                max_atomic_density=max_atomic_density,
+                min_mass_density=min_mass_density,
+                max_mass_density=max_mass_density,
                 check_format=check_format,
                 check_symmetry=check_symmetry,
                 name=config.get("name", "ValidityBenchmark"),

--- a/src/lemat_genbench/lemat_scraping/lematbulk_properties.py
+++ b/src/lemat_genbench/lemat_scraping/lematbulk_properties.py
@@ -4,11 +4,6 @@ from datasets import load_dataset
 from pymatgen.core import Structure
 from tqdm import tqdm
 
-from lemat_genbench.utils.distribution_utils import (
-    map_space_group_to_crystal_system,
-    one_hot_encode_composition,
-)
-
 # Crystal System Mapping Reference
 # ================================
 # Integer | Crystal System | Space Group Range

--- a/src/lemat_genbench/lemat_scraping/lematbulk_properties.py
+++ b/src/lemat_genbench/lemat_scraping/lematbulk_properties.py
@@ -48,23 +48,23 @@ def process_item(item):
     volume = strut.volume
     num_atoms = len(strut)
     atomic_density = num_atoms / volume
-    space_group = strut.get_space_group_info()[1]
-    crystal_system = map_space_group_to_crystal_system(space_group)
+    # space_group = strut.get_space_group_info()[1]
+    # crystal_system = map_space_group_to_crystal_system(space_group)
     
     # Compositional properties
-    one_hot_vectors = one_hot_encode_composition(strut.composition)
-    composition_counts = one_hot_vectors[0]  # Element counts
-    composition = one_hot_vectors[1]  # Element presence/absence
+    # one_hot_vectors = one_hot_encode_composition(strut.composition)
+    # composition_counts = one_hot_vectors[0]  # Element counts
+    # composition = one_hot_vectors[1]  # Element presence/absence
 
     return [
         LeMatID,
         volume,
         round(g_cm3_density, 2),
-        round(atomic_density, 2),
-        space_group,
-        crystal_system,
-        composition_counts,
-        composition,
+        round(atomic_density, 5),
+        # space_group,
+        # crystal_system,
+        # composition_counts,
+        # composition,
     ]
 
 
@@ -92,6 +92,8 @@ if __name__ == "__main__":
     name = "compatible_pbe"
     split = "train"
     dataset = load_dataset(dataset_name, name=name, split=split, streaming=False)
+    # dataset = dataset.select(range(0,100000))
+
     # Process and handle results as they come
     print(f"Processing {len(dataset)} structures using {cpu_count()} workers...")
     results = []
@@ -108,10 +110,10 @@ if __name__ == "__main__":
             "Volume",
             "Density(g/cm^3)",
             "Density(atoms/A^3)",
-            "SpaceGroup",
-            "CrystalSystem",
-            "CompositionCounts",
-            "Composition",
+            # "SpaceGroup",
+            # "CrystalSystem",
+            # "CompositionCounts",
+            # "Composition",
         ],
     )
-    df.to_pickle("data/lematbulk_full_distribution_properties.pkl")
+    df.to_csv("data/lematbulk_density_properties.csv")

--- a/src/lemat_genbench/metrics/validity_metrics.py
+++ b/src/lemat_genbench/metrics/validity_metrics.py
@@ -194,7 +194,6 @@ class ChargeNeutralityMetric(BaseMetric):
             if score > 0.001:
                 return 0.0  # Assume charge neutral (reasonable composition)
             else:
-                print("failed penalty")
                 return 0.0  # Small deviation penalty (charge balanced using LeMatBulk oxidation states, but requires unusual states)
         except IndexError:
 
@@ -517,7 +516,8 @@ class PhysicalPlausibilityMetric(BaseMetric):
         try:
             volume = structure.volume
             num_atoms = len(structure)
-            atomic_density = num_atoms / volume    
+            atomic_density = num_atoms / volume  
+
 
             if min_atomic_density <= atomic_density <= max_atomic_density:
                 checks_passed += 1
@@ -565,8 +565,7 @@ class PhysicalPlausibilityMetric(BaseMetric):
                 checks_passed += 1
             except Exception as e:
                 logger.debug(f"Format check failed: {str(e)}")
-
-        # 4. Symmetry check (optional)
+        # 5. Symmetry check (optional)
         if check_symmetry:
             total_checks += 1
             try:
@@ -586,6 +585,7 @@ class PhysicalPlausibilityMetric(BaseMetric):
         )
 
         # Return 1.0 if ALL checks passed, 0.0 otherwise
+
         return 1.0 if checks_passed == total_checks else 0.0
 
     def aggregate_results(self, values: list[float]) -> Dict[str, Any]:
@@ -816,7 +816,7 @@ if __name__ == "__main__":
     np.random.seed(32)
     indicies = np.random.randint(0, len(dataset), 50)
 
-    metric = ChargeNeutralityMetric()
+    metric = PhysicalPlausibilityMetric()
     args = metric._get_compute_attributes()
 
     structures = []

--- a/src/lemat_genbench/metrics/validity_metrics.py
+++ b/src/lemat_genbench/metrics/validity_metrics.py
@@ -524,7 +524,7 @@ class PhysicalPlausibilityMetric(BaseMetric):
 
             else:
                 logger.debug(
-                    f"Density check failed: {atomic_density:.3f} g/cm³ "
+                    f"Atomic density check failed: {atomic_density:.5f} atoms/A³ "
                     f"(not in range [{min_atomic_density}, {max_atomic_density}])"
                 )
         except Exception as e:

--- a/src/lemat_genbench/metrics/validity_metrics.py
+++ b/src/lemat_genbench/metrics/validity_metrics.py
@@ -418,9 +418,9 @@ class PhysicalPlausibilityConfig(MetricConfig):
 
     Parameters
     ----------
-    min_density : float, default=0.01
+    min_mass_density : float, default=0.01
         Minimum allowed density in g/cm³.
-    max_density : float, default=25.0
+    max_mass_density : float, default=25.0
         Maximum allowed density in g/cm³.
     check_format : bool, default=True
         Whether to check CIF format round-trip validity.
@@ -428,8 +428,8 @@ class PhysicalPlausibilityConfig(MetricConfig):
         Whether to check space group validity.
     """
 
-    min_density: float = 0.01
-    max_density: float = 25.0
+    min_mass_density: float = 0.01
+    max_mass_density: float = 25.0
     check_format: bool = True
     check_symmetry: bool = True
 
@@ -439,8 +439,8 @@ class PhysicalPlausibilityMetric(BaseMetric):
 
     def __init__(
         self,
-        min_density: float = 0.01,
-        max_density: float = 25.0,
+        min_mass_density: float = 0.01,
+        max_mass_density: float = 25.0,
         check_format: bool = True,
         check_symmetry: bool = True,
         name: str = "PhysicalPlausibility",
@@ -457,8 +457,8 @@ class PhysicalPlausibilityMetric(BaseMetric):
 
         # Override with custom config
         self.config = PhysicalPlausibilityConfig(
-            min_density=min_density,
-            max_density=max_density,
+            min_mass_density=min_mass_density,
+            max_mass_density=max_mass_density,
             check_format=check_format,
             check_symmetry=check_symmetry,
             name=name,
@@ -469,8 +469,8 @@ class PhysicalPlausibilityMetric(BaseMetric):
 
     def _get_compute_attributes(self) -> dict[str, Any]:
         return {
-            "min_density": self.config.min_density,
-            "max_density": self.config.max_density,
+            "min_mass_density": self.config.min_mass_density,
+            "max_mass_density": self.config.max_mass_density,
             "check_format": self.config.check_format,
             "check_symmetry": self.config.check_symmetry,
         }
@@ -484,8 +484,8 @@ class PhysicalPlausibilityMetric(BaseMetric):
         float
             1.0 if structure passes all plausibility checks, 0.0 otherwise.
         """
-        min_density = compute_args.get("min_density", 0.01)
-        max_density = compute_args.get("max_density", 25.0)
+        min_mass_density = compute_args.get("min_mass_density", 0.01)
+        max_mass_density = compute_args.get("max_mass_density", 25.0)
         check_format = compute_args.get("check_format", True)
         check_symmetry = compute_args.get("check_symmetry", True)
 
@@ -495,12 +495,12 @@ class PhysicalPlausibilityMetric(BaseMetric):
         # 1. Density check
         try:
             density = structure.density
-            if min_density <= density <= max_density:
+            if min_mass_density <= density <= max_mass_density:
                 checks_passed += 1
             else:
                 logger.debug(
                     f"Density check failed: {density:.3f} g/cm³ "
-                    f"(not in range [{min_density}, {max_density}])"
+                    f"(not in range [{min_mass_density}, {max_mass_density}])"
                 )
         except Exception as e:
             logger.debug(f"Could not compute density: {str(e)}")
@@ -605,8 +605,8 @@ class OverallValidityMetric(BaseMetric):
         self,
         charge_tolerance: float = 0.1,
         distance_scaling: float = 0.5,
-        min_density: float = 0.01,
-        max_density: float = 25.0,
+        min_mass_density: float = 0.01,
+        max_mass_density: float = 25.0,
         check_format: bool = True,
         check_symmetry: bool = True,
         name: str = "OverallValidity",
@@ -625,8 +625,8 @@ class OverallValidityMetric(BaseMetric):
         # Store parameters for individual metrics
         self.charge_tolerance = charge_tolerance
         self.distance_scaling = distance_scaling
-        self.min_density = min_density
-        self.max_density = max_density
+        self.min_mass_density = min_mass_density
+        self.max_mass_density = max_mass_density
         self.check_format = check_format
         self.check_symmetry = check_symmetry
         
@@ -639,8 +639,8 @@ class OverallValidityMetric(BaseMetric):
             **attrs,
             "charge_tolerance": self.charge_tolerance,
             "distance_scaling": self.distance_scaling,
-            "min_density": self.min_density,
-            "max_density": self.max_density,
+            "min_mass_density": self.min_mass_density,
+            "max_mass_density": self.max_mass_density,
             "check_format": self.check_format,
             "check_symmetry": self.check_symmetry,
             "verbose": self.verbose,
@@ -659,8 +659,8 @@ class OverallValidityMetric(BaseMetric):
         # Extract parameters
         charge_tolerance = compute_args.get("charge_tolerance", 0.1)
         distance_scaling = compute_args.get("distance_scaling", 0.5)
-        min_density = compute_args.get("min_density", 0.01)
-        max_density = compute_args.get("max_density", 25.0)
+        min_mass_density = compute_args.get("min_mass_density", 0.01)
+        max_mass_density = compute_args.get("max_mass_density", 25.0)
         check_format = compute_args.get("check_format", True)
         check_symmetry = compute_args.get("check_symmetry", True)
 
@@ -695,8 +695,8 @@ class OverallValidityMetric(BaseMetric):
         try:
             plausibility_score = PhysicalPlausibilityMetric.compute_structure(
                 structure,
-                min_density=min_density,
-                max_density=max_density,
+                min_mass_density=min_mass_density,
+                max_mass_density=max_mass_density,
                 check_format=check_format,
                 check_symmetry=check_symmetry,
             )

--- a/src/lemat_genbench/metrics/validity_metrics.py
+++ b/src/lemat_genbench/metrics/validity_metrics.py
@@ -217,11 +217,6 @@ class ChargeNeutralityMetric(BaseMetric):
             except IndexError:
                 return 10.0 # large deviation penalty 
 
-        # except Exception as e:
-        #     logger.debug(f"Compositional oxidation state guessing failed: {str(e)}")
-        #     print("failed for other reason")
-        #     return 10.0  # Large penalty for failed analysis
-
     def aggregate_results(self, values: list[float]) -> Dict[str, Any]:
         """Aggregate results into final metric values.
 
@@ -418,6 +413,10 @@ class PhysicalPlausibilityConfig(MetricConfig):
 
     Parameters
     ----------
+    min_atomic_density : float, default=0.01
+        Minimum allowed density in atoms/A³.
+    max_atomic_density : float, default=25.0
+        Maximum allowed density in atoms/A³.
     min_mass_density : float, default=0.01
         Minimum allowed density in g/cm³.
     max_mass_density : float, default=25.0
@@ -427,7 +426,8 @@ class PhysicalPlausibilityConfig(MetricConfig):
     check_symmetry : bool, default=True
         Whether to check space group validity.
     """
-
+    min_atomic_density: float = 0.00001
+    max_atomic_density: float = 0.5
     min_mass_density: float = 0.01
     max_mass_density: float = 25.0
     check_format: bool = True
@@ -439,6 +439,8 @@ class PhysicalPlausibilityMetric(BaseMetric):
 
     def __init__(
         self,
+        min_atomic_density: float = 0.00001,
+        max_atomic_density: float = 0.5,
         min_mass_density: float = 0.01,
         max_mass_density: float = 25.0,
         check_format: bool = True,
@@ -457,6 +459,8 @@ class PhysicalPlausibilityMetric(BaseMetric):
 
         # Override with custom config
         self.config = PhysicalPlausibilityConfig(
+            min_atomic_density=min_atomic_density,
+            max_atomic_density=max_atomic_density,
             min_mass_density=min_mass_density,
             max_mass_density=max_mass_density,
             check_format=check_format,
@@ -469,6 +473,8 @@ class PhysicalPlausibilityMetric(BaseMetric):
 
     def _get_compute_attributes(self) -> dict[str, Any]:
         return {
+            "min_atomic_density": self.config.min_atomic_density,
+            "max_atomic_density": self.config.max_atomic_density,
             "min_mass_density": self.config.min_mass_density,
             "max_mass_density": self.config.max_mass_density,
             "check_format": self.config.check_format,
@@ -484,28 +490,47 @@ class PhysicalPlausibilityMetric(BaseMetric):
         float
             1.0 if structure passes all plausibility checks, 0.0 otherwise.
         """
+        min_atomic_density = compute_args.get("min_atomic_density", 0.00001)
+        max_atomic_density = compute_args.get("max_atomic_density", 0.5)
         min_mass_density = compute_args.get("min_mass_density", 0.01)
         max_mass_density = compute_args.get("max_mass_density", 25.0)
         check_format = compute_args.get("check_format", True)
         check_symmetry = compute_args.get("check_symmetry", True)
 
         checks_passed = 0
-        total_checks = 2  # density + lattice checks are always done
+        total_checks = 3  # atomic density, mass density, and lattice checks are always done
 
-        # 1. Density check
+        # 1. Mass density check
         try:
-            density = structure.density
-            if min_mass_density <= density <= max_mass_density:
+            mass_density = structure.density
+            if min_mass_density <= mass_density <= max_mass_density:
                 checks_passed += 1
             else:
                 logger.debug(
-                    f"Density check failed: {density:.3f} g/cm³ "
+                    f"Density check failed: {mass_density:.3f} g/cm³ "
                     f"(not in range [{min_mass_density}, {max_mass_density}])"
                 )
         except Exception as e:
             logger.debug(f"Could not compute density: {str(e)}")
 
-        # 2. Lattice check
+        # 2. Atomic density check
+        try:
+            volume = structure.volume
+            num_atoms = len(structure)
+            atomic_density = num_atoms / volume    
+
+            if min_atomic_density <= atomic_density <= max_atomic_density:
+                checks_passed += 1
+
+            else:
+                logger.debug(
+                    f"Density check failed: {atomic_density:.3f} g/cm³ "
+                    f"(not in range [{min_atomic_density}, {max_atomic_density}])"
+                )
+        except Exception as e:
+            logger.debug(f"Could not compute density: {str(e)}")
+
+        # 3. Lattice check
         try:
             lattice = structure.lattice
             volume = lattice.volume
@@ -529,7 +554,7 @@ class PhysicalPlausibilityMetric(BaseMetric):
         except Exception as e:
             logger.debug(f"Could not validate lattice: {str(e)}")
 
-        # 3. Format check (optional)
+        # 4. Format check (optional)
         if check_format:
             total_checks += 1
             try:
@@ -605,6 +630,8 @@ class OverallValidityMetric(BaseMetric):
         self,
         charge_tolerance: float = 0.1,
         distance_scaling: float = 0.5,
+        min_atomic_density: float = 0.00001,
+        max_atomic_density: float = 0.5,
         min_mass_density: float = 0.01,
         max_mass_density: float = 25.0,
         check_format: bool = True,
@@ -625,6 +652,8 @@ class OverallValidityMetric(BaseMetric):
         # Store parameters for individual metrics
         self.charge_tolerance = charge_tolerance
         self.distance_scaling = distance_scaling
+        self.min_atomic_density = min_atomic_density
+        self.max_atomic_density = max_atomic_density
         self.min_mass_density = min_mass_density
         self.max_mass_density = max_mass_density
         self.check_format = check_format
@@ -639,6 +668,8 @@ class OverallValidityMetric(BaseMetric):
             **attrs,
             "charge_tolerance": self.charge_tolerance,
             "distance_scaling": self.distance_scaling,
+            "min_atomic_density": self.min_atomic_density,
+            "max_atomic_density": self.max_atomic_density,
             "min_mass_density": self.min_mass_density,
             "max_mass_density": self.max_mass_density,
             "check_format": self.check_format,
@@ -659,6 +690,8 @@ class OverallValidityMetric(BaseMetric):
         # Extract parameters
         charge_tolerance = compute_args.get("charge_tolerance", 0.1)
         distance_scaling = compute_args.get("distance_scaling", 0.5)
+        min_atomic_density = compute_args.get("min_atomic_density", 0.00001)
+        max_atomic_density = compute_args.get("max_atomic_density", 0.5)
         min_mass_density = compute_args.get("min_mass_density", 0.01)
         max_mass_density = compute_args.get("max_mass_density", 25.0)
         check_format = compute_args.get("check_format", True)
@@ -695,6 +728,8 @@ class OverallValidityMetric(BaseMetric):
         try:
             plausibility_score = PhysicalPlausibilityMetric.compute_structure(
                 structure,
+                min_atomic_density=min_atomic_density,
+                max_atomic_density=max_atomic_density,
                 min_mass_density=min_mass_density,
                 max_mass_density=max_mass_density,
                 check_format=check_format,
@@ -790,5 +825,5 @@ if __name__ == "__main__":
         strut = lematbulk_item_to_structure(dataset[index])
         structures.append(strut)
 
-    val = metric.compute_structure(structures[5], **args)
-    print(val)
+        val = metric.compute_structure(structures[i], **args)
+        print(val)

--- a/src/lemat_genbench/preprocess/validity_preprocess.py
+++ b/src/lemat_genbench/preprocess/validity_preprocess.py
@@ -368,7 +368,6 @@ class ValidityPreprocessor(BasePreprocessor):
             plausibility_score = PhysicalPlausibilityMetric.compute_structure(
                 structure, **plausibility_compute_args
             )
-            
             # Determine validity for each check
             # Note: charge_deviation should be <= tolerance for validity
             charge_valid = charge_deviation <= charge_tolerance

--- a/src/lemat_genbench/preprocess/validity_preprocess.py
+++ b/src/lemat_genbench/preprocess/validity_preprocess.py
@@ -65,6 +65,8 @@ class ValidityPreprocessorConfig(PreprocessorConfig):
     charge_tolerance: float = 0.1
     charge_strict: bool = False
     distance_scaling_factor: float = 0.5
+    plausibility_min_atomic_density: float = 0.00001
+    plausibility_max_atomic_density: float = 0.5
     plausibility_min_mass_density: float = 0.01
     plausibility_max_mass_density: float = 25.0
     plausibility_check_format: bool = True
@@ -83,6 +85,8 @@ class ValidityPreprocessorConfig(PreprocessorConfig):
             "charge_tolerance": self.charge_tolerance,
             "charge_strict": self.charge_strict,
             "distance_scaling_factor": self.distance_scaling_factor,
+            "plausibility_min_atomic_density": self.plausibility_min_atomic_density,
+            "plausibility_max_atomic_density": self.plausibility_max_atomic_density,
             "plausibility_min_mass_density": self.plausibility_min_mass_density,
             "plausibility_max_mass_density": self.plausibility_max_mass_density,
             "plausibility_check_format": self.plausibility_check_format,
@@ -119,6 +123,10 @@ class ValidityPreprocessor(BasePreprocessor):
         Whether to require determinable oxidation states for all atoms.
     distance_scaling_factor : float, default=0.5
         Factor to scale minimum interatomic distances.
+    plausibility_min_atomic_density : float, default=0.00001
+        Minimum plausible density in atoms/A³.
+    plausibility_max_atomic_density : float, default=0.5
+        Maximum plausible density in atoms/A³.
     plausibility_min_mass_density : float, default=0.01
         Minimum plausible density in g/cm³.
     plausibility_max_mass_density : float, default=25.0
@@ -156,6 +164,8 @@ class ValidityPreprocessor(BasePreprocessor):
         charge_tolerance: float = 0.1,
         charge_strict: bool = False,
         distance_scaling_factor: float = 0.5,
+        plausibility_min_atomic_density: float = 0.00001,
+        plausibility_max_atomic_density: float = 0.5,
         plausibility_min_mass_density: float = 0.01,
         plausibility_max_mass_density: float = 25.0,
         plausibility_check_format: bool = True,
@@ -177,6 +187,8 @@ class ValidityPreprocessor(BasePreprocessor):
             charge_tolerance=charge_tolerance,
             charge_strict=charge_strict,
             distance_scaling_factor=distance_scaling_factor,
+            plausibility_min_atomic_density=plausibility_min_atomic_density,
+            plausibility_max_atomic_density=plausibility_max_atomic_density,
             plausibility_min_mass_density=plausibility_min_mass_density,
             plausibility_max_mass_density=plausibility_max_mass_density,
             plausibility_check_format=plausibility_check_format,
@@ -192,6 +204,8 @@ class ValidityPreprocessor(BasePreprocessor):
             scaling_factor=distance_scaling_factor,
         )
         self.plausibility_metric = PhysicalPlausibilityMetric(
+            min_atomic_density=plausibility_min_atomic_density,
+            max_atomic_density=plausibility_max_atomic_density,
             min_mass_density=plausibility_min_mass_density,
             max_mass_density=plausibility_max_mass_density,
             check_format=plausibility_check_format,

--- a/src/lemat_genbench/preprocess/validity_preprocess.py
+++ b/src/lemat_genbench/preprocess/validity_preprocess.py
@@ -50,9 +50,9 @@ class ValidityPreprocessorConfig(PreprocessorConfig):
         Whether to require determinable oxidation states for all atoms.
     distance_scaling_factor : float
         Factor to scale minimum interatomic distances.
-    plausibility_min_density : float
+    plausibility_min_mass_density : float
         Minimum plausible density in g/cm³.
-    plausibility_max_density : float
+    plausibility_max_mass_density : float
         Maximum plausible density in g/cm³.
     plausibility_check_format : bool
         Whether to check crystallographic format validity.
@@ -65,8 +65,8 @@ class ValidityPreprocessorConfig(PreprocessorConfig):
     charge_tolerance: float = 0.1
     charge_strict: bool = False
     distance_scaling_factor: float = 0.5
-    plausibility_min_density: float = 0.01
-    plausibility_max_density: float = 25.0
+    plausibility_min_mass_density: float = 0.01
+    plausibility_max_mass_density: float = 25.0
     plausibility_check_format: bool = True
     plausibility_check_symmetry: bool = True
 
@@ -83,8 +83,8 @@ class ValidityPreprocessorConfig(PreprocessorConfig):
             "charge_tolerance": self.charge_tolerance,
             "charge_strict": self.charge_strict,
             "distance_scaling_factor": self.distance_scaling_factor,
-            "plausibility_min_density": self.plausibility_min_density,
-            "plausibility_max_density": self.plausibility_max_density,
+            "plausibility_min_mass_density": self.plausibility_min_mass_density,
+            "plausibility_max_mass_density": self.plausibility_max_mass_density,
             "plausibility_check_format": self.plausibility_check_format,
             "plausibility_check_symmetry": self.plausibility_check_symmetry,
         })
@@ -119,9 +119,9 @@ class ValidityPreprocessor(BasePreprocessor):
         Whether to require determinable oxidation states for all atoms.
     distance_scaling_factor : float, default=0.5
         Factor to scale minimum interatomic distances.
-    plausibility_min_density : float, default=0.01
+    plausibility_min_mass_density : float, default=0.01
         Minimum plausible density in g/cm³.
-    plausibility_max_density : float, default=25.0
+    plausibility_max_mass_density : float, default=25.0
         Maximum plausible density in g/cm³.
     plausibility_check_format : bool, default=True
         Whether to check crystallographic format validity.
@@ -156,8 +156,8 @@ class ValidityPreprocessor(BasePreprocessor):
         charge_tolerance: float = 0.1,
         charge_strict: bool = False,
         distance_scaling_factor: float = 0.5,
-        plausibility_min_density: float = 0.01,
-        plausibility_max_density: float = 25.0,
+        plausibility_min_mass_density: float = 0.01,
+        plausibility_max_mass_density: float = 25.0,
         plausibility_check_format: bool = True,
         plausibility_check_symmetry: bool = True,
         name: str = None,
@@ -177,8 +177,8 @@ class ValidityPreprocessor(BasePreprocessor):
             charge_tolerance=charge_tolerance,
             charge_strict=charge_strict,
             distance_scaling_factor=distance_scaling_factor,
-            plausibility_min_density=plausibility_min_density,
-            plausibility_max_density=plausibility_max_density,
+            plausibility_min_mass_density=plausibility_min_mass_density,
+            plausibility_max_mass_density=plausibility_max_mass_density,
             plausibility_check_format=plausibility_check_format,
             plausibility_check_symmetry=plausibility_check_symmetry,
         )
@@ -192,8 +192,8 @@ class ValidityPreprocessor(BasePreprocessor):
             scaling_factor=distance_scaling_factor,
         )
         self.plausibility_metric = PhysicalPlausibilityMetric(
-            min_density=plausibility_min_density,
-            max_density=plausibility_max_density,
+            min_mass_density=plausibility_min_mass_density,
+            max_mass_density=plausibility_max_mass_density,
             check_format=plausibility_check_format,
             check_symmetry=plausibility_check_symmetry,
         )

--- a/tests/benchmarks/test_validity_benchmark.py
+++ b/tests/benchmarks/test_validity_benchmark.py
@@ -28,6 +28,8 @@ class TestValidityBenchmark:
         benchmark = ValidityBenchmark(
             charge_tolerance=0.05,
             distance_scaling=0.3,
+            min_atomic_density=0.01,
+            max_atomic_density=0.2,
             min_mass_density=2.0,
             max_mass_density=20.0,
             check_format=False,
@@ -204,6 +206,8 @@ class TestValidityBenchmark:
         strict_benchmark = ValidityBenchmark(
             charge_tolerance=0.001,
             distance_scaling=0.9,
+            min_atomic_density=0.01,
+            max_atomic_density=0.2,
             min_mass_density=2.0,
             max_mass_density=20.0,
             check_format=True,
@@ -214,6 +218,8 @@ class TestValidityBenchmark:
         lenient_benchmark = ValidityBenchmark(
             charge_tolerance=1.0,
             distance_scaling=0.1,
+            min_atomic_density=0.00001,
+            max_atomic_density=0.5,
             min_mass_density=0.1,
             max_mass_density=50.0,
             check_format=False,

--- a/tests/benchmarks/test_validity_benchmark.py
+++ b/tests/benchmarks/test_validity_benchmark.py
@@ -28,8 +28,8 @@ class TestValidityBenchmark:
         benchmark = ValidityBenchmark(
             charge_tolerance=0.05,
             distance_scaling=0.3,
-            min_density=2.0,
-            max_density=20.0,
+            min_mass_density=2.0,
+            max_mass_density=20.0,
             check_format=False,
             check_symmetry=False,
             name="Custom Benchmark",
@@ -204,8 +204,8 @@ class TestValidityBenchmark:
         strict_benchmark = ValidityBenchmark(
             charge_tolerance=0.001,
             distance_scaling=0.9,
-            min_density=2.0,
-            max_density=20.0,
+            min_mass_density=2.0,
+            max_mass_density=20.0,
             check_format=True,
             check_symmetry=True
         )
@@ -214,8 +214,8 @@ class TestValidityBenchmark:
         lenient_benchmark = ValidityBenchmark(
             charge_tolerance=1.0,
             distance_scaling=0.1,
-            min_density=0.1,
-            max_density=50.0,
+            min_mass_density=0.1,
+            max_mass_density=50.0,
             check_format=False,
             check_symmetry=False
         )

--- a/tests/metrics/test_validity_metrics.py
+++ b/tests/metrics/test_validity_metrics.py
@@ -143,7 +143,7 @@ def test_overall_validity_metric(valid_structures, invalid_structures):
         min_atomic_density=0.00001,
         max_atomic_density=0.5,
         min_mass_density=0.01,
-        max_density=25.0,
+        max_mass_density=25.0,
         check_format=False,  # Skip for speed
         check_symmetry=False,
     )

--- a/tests/metrics/test_validity_metrics.py
+++ b/tests/metrics/test_validity_metrics.py
@@ -140,6 +140,8 @@ def test_overall_validity_metric(valid_structures, invalid_structures):
     metric = OverallValidityMetric(
         charge_tolerance=0.1,
         distance_scaling=0.5,
+        min_atomic_density=0.00001,
+        max_atomic_density=0.5,
         min_mass_density=0.01,
         max_density=25.0,
         check_format=False,  # Skip for speed
@@ -319,6 +321,8 @@ def test_overall_validity_parameters():
     strict_metric = OverallValidityMetric(
         charge_tolerance=0.001,
         distance_scaling=0.9,
+        min_atomic_density=0.01,
+        max_atomic_density=0.2,
         min_mass_density=2.0,
         max_mass_density=20.0,
         check_format=True,
@@ -329,6 +333,8 @@ def test_overall_validity_parameters():
     lenient_metric = OverallValidityMetric(
         charge_tolerance=1.0,
         distance_scaling=0.1,
+        min_atomic_density=0.00001,
+        max_atomic_density=0.5,
         min_mass_density=0.1,
         max_mass_density=50.0,
         check_format=False,

--- a/tests/metrics/test_validity_metrics.py
+++ b/tests/metrics/test_validity_metrics.py
@@ -140,7 +140,7 @@ def test_overall_validity_metric(valid_structures, invalid_structures):
     metric = OverallValidityMetric(
         charge_tolerance=0.1,
         distance_scaling=0.5,
-        min_density=0.01,
+        min_mass_density=0.01,
         max_density=25.0,
         check_format=False,  # Skip for speed
         check_symmetry=False,
@@ -319,8 +319,8 @@ def test_overall_validity_parameters():
     strict_metric = OverallValidityMetric(
         charge_tolerance=0.001,
         distance_scaling=0.9,
-        min_density=2.0,
-        max_density=20.0,
+        min_mass_density=2.0,
+        max_mass_density=20.0,
         check_format=True,
         check_symmetry=True
     )
@@ -329,8 +329,8 @@ def test_overall_validity_parameters():
     lenient_metric = OverallValidityMetric(
         charge_tolerance=1.0,
         distance_scaling=0.1,
-        min_density=0.1,
-        max_density=50.0,
+        min_mass_density=0.1,
+        max_mass_density=50.0,
         check_format=False,
         check_symmetry=False
     )


### PR DESCRIPTION
This PR adds the atomic density (atoms/A^3) to the physical plausibility metrics tested. Previously, only the mass density (g/cm^3) was tested in this metric, now both are tested. The default values for the valid atomic density range are taken from calculating the atomic density for all structures in lematbulk and widening the range slightly so all these atomic densities would be declared valid, with some additional wiggle room on either side. These changes are fully integrated to the benchmarking classes and the run_benchmarks.py script. 

